### PR TITLE
Add systems.csv file to act as a registry for systems providing GBFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ More information:
 
 * [systems.csv](systems.csv)
 
-If you would like to add a system, please fork this repository and submit a pull request. Please keep this list alphabetized by system name.
+If you would like to add a system, please fork this repository and submit a pull request. Please keep this list alphabetized by country and system name.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ More information:
 
 * [Current spec](gbfs.md)
 * [Original draft spec in a Google doc](https://docs.google.com/document/d/1BQPZCKpem4-n6lUQDD4Mi8E5hNZ0-lhY62IVtWuyhec/edit#heading=h.ic7i1m4gcev7) (reference only)
+
+## Systems Implementing GBFS
+
+* [systems.csv](systems.csv)
+
+If you would like to add a system, please fork this repository and submit a pull request. Please keep this list alphabetized by system name.

--- a/systems.csv
+++ b/systems.csv
@@ -1,16 +1,16 @@
-Name,Location,URL,Auto-Discovery URL
-Bike Share Jackson Hole,"Jackson Hole, WY",https://jacksonhole.socialbicycles.com/,https://jacksonhole.socialbicycles.com/opendata/gbfs.json
-Bishop Ranch BRiteBikes,"San Ramon, CA",http://britebikes.socialbicycles.com/,http://britebikes.socialbicycles.com/opendata/gbfs.json
-Boise Green Bike,"Boise, ID",http://boise.greenbike.com/,http://boise.greenbike.com/opendata/gbfs.json
-Breeze Bike Share,"Sana Monica, CA",http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
-Buffalo Bike Share,"Buffalo, NY",https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
-Coast Bike Share,"Tampa, FL",http://coastbikeshare.com/,http://coastbikeshare.com/opendata/gbfs.json
-Grid Bike Share,"Phoenix, AZ",http://gridbikes.com/,https://grid.socialbicycles.com/opendata/gbfs.json
-Juice,"Orlando Florida",https://orlando.socialbicycles.com/,https://orlando.socialbicycles.com/opendata/gbfs.json
-Monash Bike Share,"Monash University, Melbourne AU",https://monashbikeshare.com/,https://monashbikeshare.com/opendata/gbfs.json
-Mountain Ride Bike Share,"Ketchum / Sun Valley, ID",http://mrbikeshare.org/,http://mrbikeshare.org/opendata/gbfs.json
-Share-a-Bull Bikes,"University of South Florida",https://usf.socialbicycles.com/,https://usf.socialbicycles.com/opendata/gbfs.json
-Sobi Hamilton,"Hamilton Ontario",https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
-Sobi Long Beach,"Long Beach, CA",http://sobilongbeach.com/,http://sobilongbeach.com/opendata/gbfs.json
-Topeka Metro Bikes,"Topeka, KS",http://topekametrobikes.org/,http://topekametrobikes.org/opendata/gbfs.json
-Ubike,"University of Virginia",http://ubike.virginia.edu/,http://ubike.virginia.edu/opendata/gbfs.json
+Country Code,Name,Location,Country,URL,Auto-Discovery URL
+AU,Monash Bike Share,"Monash University, Melbourne AU",https://monashbikeshare.com/,https://monashbikeshare.com/opendata/gbfs.json
+CA,Sobi Hamilton,"Hamilton Ontario",https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
+US,Bike Share Jackson Hole,"Jackson Hole, WY",https://jacksonhole.socialbicycles.com/,https://jacksonhole.socialbicycles.com/opendata/gbfs.json
+US,Bishop Ranch BRiteBikes,"San Ramon, CA",http://britebikes.socialbicycles.com/,http://britebikes.socialbicycles.com/opendata/gbfs.json
+US,Boise Green Bike,"Boise, ID",http://boise.greenbike.com/,http://boise.greenbike.com/opendata/gbfs.json
+US,Breeze Bike Share,"Sana Monica, CA",http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
+US,Buffalo Bike Share,"Buffalo, NY",https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
+US,Coast Bike Share,"Tampa, FL",http://coastbikeshare.com/,http://coastbikeshare.com/opendata/gbfs.json
+US,Grid Bike Share,"Phoenix, AZ",http://gridbikes.com/,https://grid.socialbicycles.com/opendata/gbfs.json
+US,Juice,"Orlando, FL",https://orlando.socialbicycles.com/,https://orlando.socialbicycles.com/opendata/gbfs.json
+US,Mountain Ride Bike Share,"Ketchum / Sun Valley, ID",http://mrbikeshare.org/,http://mrbikeshare.org/opendata/gbfs.json
+US,Share-a-Bull Bikes,"University of South Florida",https://usf.socialbicycles.com/,https://usf.socialbicycles.com/opendata/gbfs.json
+US,Sobi Long Beach,"Long Beach, CA",http://sobilongbeach.com/,http://sobilongbeach.com/opendata/gbfs.json
+US,Topeka Metro Bikes,"Topeka, KS",http://topekametrobikes.org/,http://topekametrobikes.org/opendata/gbfs.json
+US,Ubike,"University of Virginia",http://ubike.virginia.edu/,http://ubike.virginia.edu/opendata/gbfs.json

--- a/systems.csv
+++ b/systems.csv
@@ -1,4 +1,4 @@
-Country Code,Name,Location,Country,URL,Auto-Discovery URL
+Country Code,Name,Location,URL,Auto-Discovery URL
 AU,Monash Bike Share,"Monash University, Melbourne AU",https://monashbikeshare.com/,https://monashbikeshare.com/opendata/gbfs.json
 CA,Sobi Hamilton,"Hamilton Ontario",https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
 US,Bike Share Jackson Hole,"Jackson Hole, WY",https://jacksonhole.socialbicycles.com/,https://jacksonhole.socialbicycles.com/opendata/gbfs.json

--- a/systems.csv
+++ b/systems.csv
@@ -1,0 +1,16 @@
+Name,Location,URL,Auto-Discovery URL
+Bike Share Jackson Hole,"Jackson Hole, WY",https://jacksonhole.socialbicycles.com/,https://jacksonhole.socialbicycles.com/opendata/gbfs.json
+Bishop Ranch BRiteBikes,"San Ramon, CA",http://britebikes.socialbicycles.com/,http://britebikes.socialbicycles.com/opendata/gbfs.json
+Boise Green Bike,"Boise, ID",http://boise.greenbike.com/,http://boise.greenbike.com/opendata/gbfs.json
+Breeze Bike Share,"Sana Monica, CA",http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
+Buffalo Bike Share,"Buffalo, NY",https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
+Coast Bike Share,"Tampa, FL",http://coastbikeshare.com/,http://coastbikeshare.com/opendata/gbfs.json
+Grid Bike Share,"Phoenix, AZ",http://gridbikes.com/,https://grid.socialbicycles.com/opendata/gbfs.json
+Juice,"Orlando Florida",https://orlando.socialbicycles.com/,https://orlando.socialbicycles.com/opendata/gbfs.json
+Monash Bike Share,"Monash University, Melbourne AU",https://monashbikeshare.com/,https://monashbikeshare.com/opendata/gbfs.json
+Mountain Ride Bike Share,"Ketchum / Sun Valley, ID",http://mrbikeshare.org/,http://mrbikeshare.org/opendata/gbfs.json
+Share-a-Bull Bikes,"University of South Florida",https://usf.socialbicycles.com/,https://usf.socialbicycles.com/opendata/gbfs.json
+Sobi Hamilton,"Hamilton Ontario",https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
+Sobi Long Beach,"Long Beach, CA",http://sobilongbeach.com/,http://sobilongbeach.com/opendata/gbfs.json
+Topeka Metro Bikes,"Topeka, KS",http://topekametrobikes.org/,http://topekametrobikes.org/opendata/gbfs.json
+Ubike,"University of Virginia",http://ubike.virginia.edu/,http://ubike.virginia.edu/opendata/gbfs.json

--- a/systems.csv
+++ b/systems.csv
@@ -1,16 +1,15 @@
-Country Code,Name,Location,URL,Auto-Discovery URL
-AU,Monash Bike Share,"Monash University, Melbourne AU",https://monashbikeshare.com/,https://monashbikeshare.com/opendata/gbfs.json
-CA,Sobi Hamilton,"Hamilton Ontario",https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
-US,Bike Share Jackson Hole,"Jackson Hole, WY",https://jacksonhole.socialbicycles.com/,https://jacksonhole.socialbicycles.com/opendata/gbfs.json
-US,Bishop Ranch BRiteBikes,"San Ramon, CA",http://britebikes.socialbicycles.com/,http://britebikes.socialbicycles.com/opendata/gbfs.json
-US,Boise Green Bike,"Boise, ID",http://boise.greenbike.com/,http://boise.greenbike.com/opendata/gbfs.json
-US,Breeze Bike Share,"Sana Monica, CA",http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
-US,Buffalo Bike Share,"Buffalo, NY",https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
-US,Coast Bike Share,"Tampa, FL",http://coastbikeshare.com/,http://coastbikeshare.com/opendata/gbfs.json
-US,Grid Bike Share,"Phoenix, AZ",http://gridbikes.com/,https://grid.socialbicycles.com/opendata/gbfs.json
-US,Juice,"Orlando, FL",https://orlando.socialbicycles.com/,https://orlando.socialbicycles.com/opendata/gbfs.json
-US,Mountain Ride Bike Share,"Ketchum / Sun Valley, ID",http://mrbikeshare.org/,http://mrbikeshare.org/opendata/gbfs.json
-US,Share-a-Bull Bikes,"University of South Florida",https://usf.socialbicycles.com/,https://usf.socialbicycles.com/opendata/gbfs.json
-US,Sobi Long Beach,"Long Beach, CA",http://sobilongbeach.com/,http://sobilongbeach.com/opendata/gbfs.json
-US,Topeka Metro Bikes,"Topeka, KS",http://topekametrobikes.org/,http://topekametrobikes.org/opendata/gbfs.json
-US,Ubike,"University of Virginia",http://ubike.virginia.edu/,http://ubike.virginia.edu/opendata/gbfs.json
+Country Code,Name,Location,System ID,URL,Auto-Discovery URL
+AU,Monash Bike Share,"Monash University, Melbourne AU",monash_bike_share,https://monashbikeshare.com/,https://monashbikeshare.com/opendata/gbfs.json
+CA,Sobi Hamilton,"Hamilton Ontario",sobi_hamilton,https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
+US,Bishop Ranch BRiteBikes,"San Ramon, CA",bishop_ranch,http://britebikes.socialbicycles.com/,http://britebikes.socialbicycles.com/opendata/gbfs.json
+US,Boise Green Bike,"Boise, ID",boise_greenbike,http://boise.greenbike.com/,http://boise.greenbike.com/opendata/gbfs.json
+US,Breeze Bike Share,"Sana Monica, CA",breeze_bikeshare,http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
+US,Buffalo Bike Share,"Buffalo, NY",buffalo_bike_share,https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
+US,Coast Bike Share,"Tampa, FL",coast_bike_share,http://coastbikeshare.com/,http://coastbikeshare.com/opendata/gbfs.json
+US,Grid Bike Share,"Phoenix, AZ",grid_bike_share,http://gridbikes.com/,https://grid.socialbicycles.com/opendata/gbfs.json
+US,Juice,"Orlando, FL",juice_bike_share,https://orlando.socialbicycles.com/,https://orlando.socialbicycles.com/opendata/gbfs.json
+US,Mountain Ride Bike Share,"Ketchum / Sun Valley, ID",mountain_rides_bike_share,http://mrbikeshare.org/,http://mrbikeshare.org/opendata/gbfs.json
+US,Share-a-Bull Bikes,"University of South Florida",usf_share-a-bull_bikes,https://usf.socialbicycles.com/,https://usf.socialbicycles.com/opendata/gbfs.json
+US,Sobi Long Beach,"Long Beach, CA",sobi_long_beach,http://sobilongbeach.com/,http://sobilongbeach.com/opendata/gbfs.json
+US,Topeka Metro Bikes,"Topeka, KS",topeka_metro_bikes,http://topekametrobikes.org/,http://topekametrobikes.org/opendata/gbfs.json
+US,Ubike,"University of Virginia",university_of_virginia,http://ubike.virginia.edu/,http://ubike.virginia.edu/opendata/gbfs.json


### PR DESCRIPTION
Based on the list originally from @mplsmitch I'd like to propose this format for our "system registry" CSV file. I like CSV on Github because it's human-readable and searchable. You can see what this file will look like at https://github.com/jcn/gbfs/blob/systems-list/systems.csv

Looking for comments and/or validation from the other contributors. I will merge this into master if I do not get any comments by the end of the week. 
