### PR TITLE
Add CC-BY license to the actual gbfs.md file

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -326,6 +326,10 @@ There are some items that were proposed in an earlier version of this document b
 * station_status.json
     * need a way to distinguish between multiple bike types at a station if/when  hybrid systems using e-bikes become available
 
-**Disclaimers**
+## Disclaimers
 
 _Apple Pay, PayPass and other third-party product and service names are trademarks or registered trademarks of their respective owners._
+
+## License
+
+Except as otherwise noted, the content of this page is licensed under the [Creative Commons Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
As per https://github.com/NABSA/gbfs/issues/22 I am submitting this proposed language to license the content of the `gbfs.md` file under CC-BY. This presumably does not affect the other pages in the repository (including the `systems.csv` file) which I think is the right call.

As per our emerging practices, I will leave this PR open until Friday April 29 at 5pm ET at which point, if nobody complains, I will merge it into master.

Closes #22
