### PR TITLE
Add license_url to system_information feed

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -171,6 +171,7 @@ start_date        | Optional  | String in the form YYYY-MM-DD representing the d
 phone_number      | Optional  | A single voice telephone number for the specified system. This field is a string value that presents the telephone number as typical for the system's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, Capital Bikeshare’s  "877-430-BIKE") is permitted, but the field must not contain any other descriptive text
 email             | Optional  | A single contact email address for customers to address questions about the system
 timezone          | Yes       | The time zone where the system is located. Time zone names never contain the space character but may contain an underscore. Please refer to the "TZ" value in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid values
+license_url       | Optional  | A fully qualified URL of a page that defines the license terms for the GBFS data for this system, as well as any other license terms the system would like to define (including the use of corporate trademarks, etc)
 
 
 ### station_information.json


### PR DESCRIPTION
As per https://github.com/NABSA/gbfs/issues/45, define the URL for a license page to make it easier for consumers to know how they can use the data in the feed (and any other terms regarding the system).

Please note that this proposal adds the `license_url` to system information instead of to the main auto-discovery page. It seems to me that auto-discover should just be used to point to the other feeds, and since the license page is going to end up being defined by the vendor or system, and because the license could be for things other than just GBFS (i.e. restrictions on trademark use for the entire system), I thought it made more sense in the system_information section.

Comments welcome until August 26 at 5pm ET at which point I'll merge this in to the spec.
