### PR TITLE
Buffalo BSS rebranding, feed no longer exists

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -13,7 +13,6 @@ US,Boulder B-cycle,"Boulder, CO",bcycle_boulder,https://boulder.bcycle.com,https
 US,Breeze Bike Share,"Sana Monica, CA",breeze_bikeshare,http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
 US,Broward B-cycle,"Fort Lauderdale, FL",bcycle_broward,https://broward.bcycle.com,https://gbfs.bcycle.com/bcycle_broward/gbfs.json
 US,Bublr Bikes,"Milwaukee, WI",bcycle_bublr,http://bublrbikes.com,https://gbfs.bcycle.com/bcycle_bublr/gbfs.json
-US,Buffalo Bike Share,"Buffalo, NY",buffalo_bike_share,https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
 US,Capital Bike Share,"Washington, DC",cabi,http://www.capitalbikeshare.com,https://gbfs.capitalbikeshare.com/gbfs/gbfs.json
 US,Charlotte B-cycle,"Charlotte, NC",bcycle_charlotte,https://charlotte.bcycle.com,https://gbfs.bcycle.com/bcycle_charlotte/gbfs.json
 US,Cincy Red Bike,"Cincinnati, OH",bcycle_cincyredbike,http://www.cincyredbike.org,https://gbfs.bcycle.com/bcycle_cincyredbike/gbfs.json

--- a/systems.csv
+++ b/systems.csv
@@ -9,7 +9,6 @@ US,Boulder B-cycle,"Boulder, CO",bcycle_boulder,https://boulder.bcycle.com,https
 US,Breeze Bike Share,"Sana Monica, CA",breeze_bikeshare,http://santamonicabikeshare.com/,http://santamonicabikeshare.com/opendata/gbfs.json
 US,Broward B-cycle,"Fort Lauderdale, FL",bcycle_broward,https://broward.bcycle.com,https://gbfs.bcycle.com/bcycle_broward/gbfs.json
 US,Bublr Bikes,"Milwaukee, WI",bcycle_bublr,http://bublrbikes.com,https://gbfs.bcycle.com/bcycle_bublr/gbfs.json
-US,Buffalo Bike Share,"Buffalo, NY",buffalo_bike_share,https://buffalo.socialbicycles.com/,https://buffalo.socialbicycles.com/opendata/gbfs.json
 US,Capital Bike Share,"Washington, DC",cabi,http://www.capitalbikeshare.com,https://gbfs.capitalbikeshare.com/gbfs/gbfs.json
 US,Charlotte B-cycle,"Charlotte, NC",bcycle_charlotte,https://charlotte.bcycle.com,https://gbfs.bcycle.com/bcycle_charlotte/gbfs.json
 US,Cincy Red Bike,"Cincinnati, OH",bcycle_cincyredbike,http://www.cincyredbike.org,https://gbfs.bcycle.com/bcycle_cincyredbike/gbfs.json


### PR DESCRIPTION
Buffalo's rebranding/relaunch of their BSS to 'Reddy bikeshare' has made the current feed info in **systems.csv** obsolete. I can't find a replacement GBFS feed. Perhaps someone from SOBI can submit updated info and GBFS url and then disregard this pull request?
