### PR TITLE
Orlando Juice no longer provides GBFS format feed

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -34,7 +34,6 @@ US,Houston B-cycle,"Houston, TX",bcycle_houston,https://houston.bcycle.com,https
 US,Hubway,"Boston, MA",hubway,https://www.thehubway.com,https://gbfs.thehubway.com/gbfs/gbfs.json
 US,Indego,"Philadelphia, PA",bcycle_indego,https://www.rideindego.com,https://gbfs.bcycle.com/bcycle_indego/gbfs.json
 US,Indy - Pacers Bikeshare,"Indianapolis, IN",bcycle_pacersbikeshare,https://www.pacersbikeshare.org,https://gbfs.bcycle.com/bcycle_pacersbikeshare/gbfs.json
-US,Juice,"Orlando, FL",juice_bike_share,https://orlando.socialbicycles.com/,https://orlando.socialbicycles.com/opendata/gbfs.json
 US,Kansas City B-cycle,"Kansas City, MO",bcycle_kc,https://kc.bcycle.com,https://gbfs.bcycle.com/bcycle_kc/gbfs.json
 US,Link Dayton Bike Share,"Dayton, OH",bcycle_linkdayton,https://www.linkdayton.org,https://gbfs.bcycle.com/bcycle_linkdayton/gbfs.json
 US,Madison B-cycle,"Madison, WI",bcycle_madison,https://madison.bcycle.com,https://gbfs.bcycle.com/bcycle_madison/gbfs.json


### PR DESCRIPTION
Either their server has some problems or it's abandoned:
https://orlando.socialbicycles.com/opendata/gbfs.json