### PR TITLE
Added JSON Schema (#37)

### DIFF
--- a/schema/free_bike_status.json
+++ b/schema/free_bike_status.json
@@ -1,0 +1,65 @@
+{
+  "definitions": {
+    "Bike": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "bike_id": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number"
+        },
+        "lon": {
+          "type": "number"
+        },
+        "is_reserved": {
+          "type": "string"
+        },
+        "is_disabled": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bike_id",
+        "lat",
+        "lon",
+        "is_reserved",
+        "is_disabled"
+      ]
+    },
+    "FreeBikeStatusData": {
+      "type": "object",
+      "properties": {
+        "bikes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Bike"
+          }
+        }
+      },
+      "required": [
+        "bikes"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/FreeBikeStatusData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/free_bike_status.json
+++ b/schema/free_bike_status.json
@@ -75,8 +75,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/free_bike_status.json
+++ b/schema/free_bike_status.json
@@ -1,25 +1,40 @@
 {
+  "description": "Describes bikes that are available in non station-based systems.",
   "definitions": {
     "Bike": {
+      "description": "A bike that is currently docked/stopped outside of the system",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "bike_id": {
+          "description": "Unique identifier of a bike.",
           "type": "string"
         },
         "lat": {
-          "type": "number"
+          "description": "Latitude of the bike. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees.",
+          "type": "number",
+          "minimum": -90.0,
+          "maximum": 90.0
         },
         "lon": {
-          "type": "number"
+          "description": "Longitude of the bike. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees.",
+          "type": "number",
+          "minimum": -180.0,
+          "maximum": 180.0
         },
         "is_reserved": {
-          "type": "string"
+          "description": "Is the bike currently reserved for someone else.",
+          "type": "integer",
+          "minimum": 0.0,
+          "maximum": 1.0
         },
         "is_disabled": {
-          "type": "string"
+          "description": "Is the bike currently disabled (broken).",
+          "type": "integer",
+          "minimum": 0.0,
+          "maximum": 1.0
         }
       },
       "required": [
@@ -31,13 +46,16 @@
       ]
     },
     "FreeBikeStatusData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "bikes": {
+          "description": "Array that contains one object per bike that is currently docked/stopped outside of the system.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Bike"
-          }
+          },
+          "minItems": 0
         }
       },
       "required": [
@@ -51,10 +69,14 @@
       "$ref": "#/definitions/FreeBikeStatusData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/gbfs.json
+++ b/schema/gbfs.json
@@ -76,8 +76,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/gbfs.json
+++ b/schema/gbfs.json
@@ -1,0 +1,71 @@
+{
+  "definitions": {
+    "Feed": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "url"
+      ]
+    },
+    "ManifestFeeds": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "feeds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Feed"
+          }
+        }
+      },
+      "required": [
+        "feeds"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/ManifestFeeds"
+      }
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/gbfs.json
+++ b/schema/gbfs.json
@@ -1,22 +1,33 @@
 {
+  "description": "Auto-discovery file that links to all of the other files published by the system.",
   "definitions": {
     "Feed": {
+      "description": "A feed published by this auto-discovery file",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "name": {
-          "type": [
-            "string",
-            "null"
+          "description": "Key identifying the type of feed this is. (e.g. \"system_information\", \"station_information\")",
+          "type": "string",
+          "enum": [
+            "gbfs",
+            "system_information",
+            "station_information",
+            "station_status",
+            "free_bike_status",
+            "system_hours",
+            "system_calendar",
+            "system_regions",
+            "system_pricing_plans",
+            "system_alerts"
           ]
         },
         "url": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Full URL for the feed.",
+          "type": "string",
+          "format": "uri"
         }
       },
       "required": [
@@ -25,42 +36,48 @@
       ]
     },
     "ManifestFeeds": {
+      "description": "The feeds in a language that all of the contained files will be published in. This language must match the value in the system_information file.",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "feeds": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "description": "An array of all of the feeds that are published by this auto-discovery file",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Feed"
-          }
+          },
+          "minItems": 3
         }
       },
       "required": [
         "feeds"
-      ]
+      ],
+      "minProperties": 1
     }
   },
   "type": "object",
   "properties": {
     "data": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": {
-        "$ref": "#/definitions/ManifestFeeds"
+      "description": "Object keyed by language that all of the contained files will be published in. This language must match the value in the system_information file.",
+      "type": "object",
+      "additionalProperties": {},
+      "patternProperties": {
+        "^[0-9A-WY-Za-wy-z]": {
+          "$ref": "#/definitions/ManifestFeeds"
+        }
       }
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/station_information.json
+++ b/schema/station_information.json
@@ -108,8 +108,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/station_information.json
+++ b/schema/station_information.json
@@ -1,91 +1,94 @@
 {
+  "description": "Mostly static list of all stations, their capacities and locations.",
   "definitions": {
     "Station": {
+      "description": "Defines a station",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "station_id": {
+          "description": "Unique identifier of a station.",
           "type": "string"
         },
         "name": {
+          "description": "Public name of the station",
           "type": "string"
         },
         "short_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Short name or other type of identifier, as used by the data publisher",
+          "type": "string"
         },
         "lat": {
-          "type": "number"
+          "description": "The latitude of station. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees",
+          "type": "number",
+          "minimum": -90.0,
+          "maximum": 90.0
         },
         "lon": {
-          "type": "number"
+          "description": "The longitude of station. The field value must be a valid WGS 84 longitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees",
+          "type": "number",
+          "minimum": -180.0,
+          "maximum": 180.0
         },
         "address": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Valid street number and name where station is located. This field is intended to be an actual address, not a free form text description (see cross_street)",
+          "type": "string"
         },
         "cross_street": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc.",
+          "type": "string"
         },
         "region_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "ID of the region where station is located (see system_regions)",
+          "type": "string"
         },
         "post_code": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Postal code where station is located",
+          "type": "string"
         },
         "rental_methods": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "description": "Array of enumerables containing the payment methods accepted at this station.",
+          "type": "array",
           "items": {
-            "type": [
-              "string",
-              "null"
+            "type": "string",
+            "enum": [
+              "KEY",
+              "CREDITCARD",
+              "PAYPASS",
+              "APPLEPAY",
+              "ANDROIDPAY",
+              "TRANSITCARD",
+              "ACCOUNTNUMBER",
+              "PHONE"
             ]
-          }
+          },
+          "minItems": 1
         },
         "capacity": {
+          "description": "Number of total docking points installed at this station, both available and unavailable",
           "type": "integer"
         }
       },
       "required": [
         "station_id",
         "name",
-        "short_name",
         "lat",
-        "lon",
-        "address",
-        "cross_street",
-        "region_id",
-        "post_code",
-        "rental_methods",
-        "capacity"
+        "lon"
       ]
     },
     "StationInformationData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "stations": {
+          "description": "Array that contains one object per station in the system",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Station"
-          }
+          },
+          "minItems": 0
         }
       },
       "required": [
@@ -99,10 +102,14 @@
       "$ref": "#/definitions/StationInformationData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/station_information.json
+++ b/schema/station_information.json
@@ -1,0 +1,113 @@
+{
+  "definitions": {
+    "Station": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "station_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "short_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lat": {
+          "type": "number"
+        },
+        "lon": {
+          "type": "number"
+        },
+        "address": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cross_street": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "region_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "post_code": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rental_methods": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "capacity": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "station_id",
+        "name",
+        "short_name",
+        "lat",
+        "lon",
+        "address",
+        "cross_street",
+        "region_id",
+        "post_code",
+        "rental_methods",
+        "capacity"
+      ]
+    },
+    "StationInformationData": {
+      "type": "object",
+      "properties": {
+        "stations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Station"
+          }
+        }
+      },
+      "required": [
+        "stations"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/StationInformationData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/station_status.json
+++ b/schema/station_status.json
@@ -1,45 +1,60 @@
 {
+  "description": "Number of available bikes and docks at each station and station availability.",
   "definitions": {
     "Status": {
+      "description": "Status of a single station",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "station_id": {
+          "description": "Unique identifier of a station (see station_information)",
           "type": "string"
         },
         "num_bikes_available": {
+          "description": "Number of bikes available for rental",
           "type": "integer"
         },
         "num_bikes_disabled": {
+          "description": "Number of disabled bikes at the station. ",
           "type": "integer"
         },
         "num_docks_available": {
+          "description": "Number of docks accepting bike returns.",
           "type": "integer"
         },
         "num_docks_disabled": {
+          "description": "Number of empty but disabled dock points at the station. This value remains as part of the spec as it is possibly useful during development.",
           "type": "integer"
         },
         "is_installed": {
-          "type": "boolean"
+          "description": "Is the station currently on the street",
+          "type": "integer",
+          "minimum": 0.0,
+          "maximum": 1.0
         },
         "is_renting": {
-          "type": "boolean"
+          "description": "Is the station currently renting bikes (even if the station is empty, if it is set to allow rentals this value should be true)",
+          "type": "integer",
+          "minimum": 0.0,
+          "maximum": 1.0
         },
         "is_returning": {
-          "type": "boolean"
+          "description": "Is the station accepting bike returns (if a station is full but would allow a return if it was not full then this value should be true)",
+          "type": "integer",
+          "minimum": 0.0,
+          "maximum": 1.0
         },
         "last_reported": {
+          "description": "Integer POSIX timestamp indicating the last time this station reported its status to the backend",
           "type": "integer"
         }
       },
       "required": [
         "station_id",
         "num_bikes_available",
-        "num_bikes_disabled",
         "num_docks_available",
-        "num_docks_disabled",
         "is_installed",
         "is_renting",
         "is_returning",
@@ -47,16 +62,16 @@
       ]
     },
     "StationStatusData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "stations": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "description": "Array that contains one object per station in the system",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Status"
-          }
+          },
+          "minItems": 0
         }
       },
       "required": [
@@ -70,10 +85,14 @@
       "$ref": "#/definitions/StationStatusData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/station_status.json
+++ b/schema/station_status.json
@@ -91,8 +91,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/station_status.json
+++ b/schema/station_status.json
@@ -1,0 +1,84 @@
+{
+  "definitions": {
+    "Status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "station_id": {
+          "type": "string"
+        },
+        "num_bikes_available": {
+          "type": "integer"
+        },
+        "num_bikes_disabled": {
+          "type": "integer"
+        },
+        "num_docks_available": {
+          "type": "integer"
+        },
+        "num_docks_disabled": {
+          "type": "integer"
+        },
+        "is_installed": {
+          "type": "boolean"
+        },
+        "is_renting": {
+          "type": "boolean"
+        },
+        "is_returning": {
+          "type": "boolean"
+        },
+        "last_reported": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "station_id",
+        "num_bikes_available",
+        "num_bikes_disabled",
+        "num_docks_available",
+        "num_docks_disabled",
+        "is_installed",
+        "is_renting",
+        "is_returning",
+        "last_reported"
+      ]
+    },
+    "StationStatusData": {
+      "type": "object",
+      "properties": {
+        "stations": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Status"
+          }
+        }
+      },
+      "required": [
+        "stations"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/StationStatusData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_alerts.json
+++ b/schema/system_alerts.json
@@ -1,107 +1,112 @@
 {
+  "description": "Describes current system alerts.",
   "definitions": {
     "AlertTime": {
+      "description": "Range of time that an alert may be in effect",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "start": {
+          "description": "Integer POSIX timestamp - required if container \"times\" key is present",
           "type": "integer"
         },
         "end": {
+          "description": "Integer POSIX timestamp - if there is currently no end time planned for the alert, this key can be omitted indicating that there is no currently scheduled end time for the alert",
           "type": "integer"
         }
       },
       "required": [
-        "start",
-        "end"
+        "start"
       ]
     },
     "Alert": {
+      "description": "An alert object indicating a system alert",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "alert_id": {
+          "description": "ID - unique identifier for this alert",
           "type": "string"
         },
         "type": {
-          "type": "string"
-        },
-        "times": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/AlertTime"
-          }
-        },
-        "station_ids": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "region_ids": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
+          "description": "Type of alert",
+          "type": "string",
+          "enum": [
+            "SYSTEM_CLOSURE",
+            "STATION_CLOSURE",
+            "STATION_MOVE",
+            "OTHER"
           ]
         },
+        "times": {
+          "description": "Array of alert times indicating when the alert is in effect (e.g. when the system or station is actually closed, or when it is scheduled to be moved). If this array is omitted then the alert should be displayed as long as it is in the feed.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertTime"
+          },
+          "minItems": 0
+        },
+        "station_ids": {
+          "description": "If this is an alert that affects one or more stations, include their ids, otherwise omit this field. If both station_ids and region_ids are omitted, assume this alert affects the entire system",
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "minItems": 0
+        },
+        "region_ids": {
+          "description": "If this system has regions, and if this alert only affects certain regions, include their ids, otherwise, omit this field. If both station_ids and region_ids are omitted, assume this alert affects the entire system",
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "minItems": 0
+        },
+        "url": {
+          "description": "URL where the customer can learn more information about this alert, if there is one",
+          "type": "string",
+          "format": "uri"
+        },
         "summary": {
+          "description": "A short summary of this alert to be displayed to the customer",
           "type": "string"
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Detailed text description of the alert",
+          "type": "string"
         },
         "last_updated": {
+          "description": "Integer POSIX timestamp indicating the last time the info for the particular alert was updated",
           "type": "integer"
         }
       },
       "required": [
         "alert_id",
         "type",
-        "times",
-        "station_ids",
-        "region_ids",
-        "url",
-        "summary",
-        "description",
-        "last_updated"
+        "summary"
       ]
     },
     "SystemAlertsData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "alerts": {
+          "description": "Array - alert objects each indicating a separate system alert ",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Alert"
-          }
+          },
+          "minItems": 0
         }
       },
       "required": [
@@ -115,10 +120,14 @@
       "$ref": "#/definitions/SystemAlertsData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/system_alerts.json
+++ b/schema/system_alerts.json
@@ -1,0 +1,129 @@
+{
+  "definitions": {
+    "AlertTime": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "start": {
+          "type": "integer"
+        },
+        "end": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ]
+    },
+    "Alert": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "alert_id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "times": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AlertTime"
+          }
+        },
+        "station_ids": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "region_ids": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_updated": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "alert_id",
+        "type",
+        "times",
+        "station_ids",
+        "region_ids",
+        "url",
+        "summary",
+        "description",
+        "last_updated"
+      ]
+    },
+    "SystemAlertsData": {
+      "type": "object",
+      "properties": {
+        "alerts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Alert"
+          }
+        }
+      },
+      "required": [
+        "alerts"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SystemAlertsData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_alerts.json
+++ b/schema/system_alerts.json
@@ -126,8 +126,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/system_calendar.json
+++ b/schema/system_calendar.json
@@ -1,50 +1,64 @@
 {
+  "description": "Describes the days of operation for the system.",
   "definitions": {
     "Calendar": {
+      "description": "Year object describing the system operational calendar.",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "start_month": {
-          "type": "integer"
+          "description": "Starting month for the system operations (1-12)",
+          "type": "integer",
+          "minimum": 1.0,
+          "maximum": 12.0
         },
         "start_day": {
-          "type": "integer"
+          "description": "Starting day for the system operations (1-31)",
+          "type": "integer",
+          "minimum": 1.0,
+          "maximum": 31.0
         },
         "start_year": {
+          "description": "Starting year for the system operations",
           "type": "integer"
         },
         "end_month": {
-          "type": "integer"
+          "description": "Ending month for the system operations (1-12)",
+          "type": "integer",
+          "minimum": 1.0,
+          "maximum": 12.0
         },
         "end_day": {
-          "type": "integer"
+          "description": "Ending day for the system operations (1-31)",
+          "type": "integer",
+          "minimum": 1.0,
+          "maximum": 31.0
         },
         "end_year": {
+          "description": "Ending year for the system operations",
           "type": "integer"
         }
       },
       "required": [
         "start_month",
         "start_day",
-        "start_year",
         "end_month",
-        "end_day",
-        "end_year"
+        "end_day"
       ]
     },
     "SystemCalendarData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "calendars": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "description": "Array of year objects describing the system operational calendar. A minimum of one calendar object is required, which could indicate a general calendar, or multiple calendars could be present indicating arbitrary start and end dates.",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Calendar"
-          }
+          },
+          "minItems": 1
         }
       },
       "required": [
@@ -58,10 +72,14 @@
       "$ref": "#/definitions/SystemCalendarData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/system_calendar.json
+++ b/schema/system_calendar.json
@@ -78,8 +78,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/system_calendar.json
+++ b/schema/system_calendar.json
@@ -1,0 +1,72 @@
+{
+  "definitions": {
+    "Calendar": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "start_month": {
+          "type": "integer"
+        },
+        "start_day": {
+          "type": "integer"
+        },
+        "start_year": {
+          "type": "integer"
+        },
+        "end_month": {
+          "type": "integer"
+        },
+        "end_day": {
+          "type": "integer"
+        },
+        "end_year": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "start_month",
+        "start_day",
+        "start_year",
+        "end_month",
+        "end_day",
+        "end_year"
+      ]
+    },
+    "SystemCalendarData": {
+      "type": "object",
+      "properties": {
+        "calendars": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Calendar"
+          }
+        }
+      },
+      "required": [
+        "calendars"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SystemCalendarData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_hours.json
+++ b/schema/system_hours.json
@@ -91,8 +91,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/system_hours.json
+++ b/schema/system_hours.json
@@ -1,0 +1,76 @@
+{
+  "definitions": {
+    "RentalHours": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "user_types": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "days": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "start_time": {
+          "type": "string"
+        },
+        "end_time": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "user_types",
+        "days",
+        "start_time",
+        "end_time"
+      ]
+    },
+    "SystemHoursData": {
+      "type": "object",
+      "properties": {
+        "rental_hours": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RentalHours"
+          }
+        }
+      },
+      "required": [
+        "rental_hours"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SystemHoursData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_hours.json
+++ b/schema/system_hours.json
@@ -1,34 +1,53 @@
 {
+  "description": "Describes the hours of operation for the system.",
   "definitions": {
     "RentalHours": {
+      "description": "An hour object",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "user_types": {
+          "description": "An array of \"member\" and \"nonmember\" values. This indicates that this set of rental hours applies to either members or non-members only.",
           "type": "array",
           "items": {
-            "type": [
-              "string",
-              "null"
+            "type": "string",
+            "enum": [
+              "member",
+              "nonmember"
             ]
-          }
+          },
+          "minItems": 1,
+          "maxItems": 2
         },
         "days": {
+          "description": "An array of abbreviations (first 3 letters) of English names of the days of the week that this hour object applies to (i.e. [\"mon\", \"tue\"]). Each day can only appear once within all of the hours objects in this feed.",
           "type": "array",
           "items": {
-            "type": [
-              "string",
-              "null"
+            "type": "string",
+            "enum": [
+              "sun",
+              "mon",
+              "tue",
+              "wed",
+              "thu",
+              "fri",
+              "sat"
             ]
-          }
+          },
+          "minItems": 1,
+          "maxItems": 7
         },
         "start_time": {
-          "type": "string"
+          "description": "Start time for the hours of operation of the system in the time zone indicated in system_information (00:00:00 - 23:59:59)",
+          "type": "string",
+          "pattern": "([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]"
         },
         "end_time": {
-          "type": "string"
+          "description": "End time for the hours of operation of the system in the time zone indicated in system_information (00:00:00 - 47:59:59). Time can stretch up to one additional day in the future to accommodate situations where, for example, a system was open from 11:30pm - 11pm the next day (i.e. 23:30-47:00)",
+          "type": "string",
+          "pattern": "([0-3][0-9]|4[0-7]):[0-5][0-9]:[0-5][0-9]"
         }
       },
       "required": [
@@ -39,16 +58,20 @@
       ]
     },
     "SystemHoursData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "rental_hours": {
+          "description": "Array of hour objects. Can contain a minimum of one object identifying hours for all days of the week or a maximum of fourteen hour objects are allowed (one for each day of the week for each \"member\" or \"nonmember\" user type)",
           "type": [
             "array",
             "null"
           ],
           "items": {
             "$ref": "#/definitions/RentalHours"
-          }
+          },
+          "minItems": 0,
+          "maxItems": 14
         }
       },
       "required": [
@@ -62,10 +85,14 @@
       "$ref": "#/definitions/SystemHoursData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/system_information.json
+++ b/schema/system_information.json
@@ -1,82 +1,70 @@
 {
+  "description": "Describes the system including System operator, System location, year implemented, URLs, contact info, time zone.",
   "definitions": {
     "SystemInformationData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "system_id": {
+          "description": "ID field - identifier for this bike share system. This should be globally unique (even between different systems) and it is currently up to the publisher of the feed to guarantee uniqueness. In addition, this value is intended to remain the same over the life of the system",
           "type": "string"
         },
         "language": {
-          "type": "string"
+          "description": "An IETF language tag indicating the language that will be used throughout the rest of the files. This is a string that defines a single language tag only. See https://tools.ietf.org/html/bcp47 and https://en.wikipedia.org/wiki/IETF_language_tag for details about the format of this tag",
+          "type": "string",
+          "pattern": "^[0-9A-WY-Za-wy-z]"
         },
         "name": {
+          "description": "Full name of the system to be displayed to customers",
           "type": "string"
         },
         "short_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Abbreviation for a system",
+          "type": "string"
         },
         "operator": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Name of the operator of the system",
+          "type": "string"
         },
         "url": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "The URL of the bike share system. The value must be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values",
+          "type": "string",
+          "format": "uri"
         },
         "purchase_url": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "A fully qualified URL where a customer can purchase a membership or learn more about purchasing memberships",
+          "type": "string",
+          "format": "uri"
         },
         "start_date": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "String in the form YYYY-MM-DD representing the date that the system began operations",
+          "type": "string",
+          "pattern": "\\d{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])"
         },
         "phone_number": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "A single voice telephone number for the specified system. This field is a string value that presents the telephone number as typical for the system's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, Capital Bikeshare’s  \"877-430-BIKE\") is permitted, but the field must not contain any other descriptive text",
+          "type": "string"
         },
         "email": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "A single contact email address for customers to address questions about the system",
+          "type": "string",
+          "format": "email"
         },
         "timezone": {
+          "description": "The time zone where the system is located. Time zone names never contain the space character but may contain an underscore. Please refer to the \"TZ\" value in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid values",
           "type": "string"
         },
         "license_url": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "A fully qualified URL of a page that defines the license terms for the GBFS data for this system, as well as any other license terms the system would like to define (including the use of corporate trademarks, etc)",
+          "type": "string",
+          "format": "uri"
         }
       },
       "required": [
         "system_id",
         "language",
         "name",
-        "short_name",
-        "operator",
-        "url",
-        "purchase_url",
-        "start_date",
-        "phone_number",
-        "email",
-        "timezone",
-        "license_url"
+        "timezone"
       ]
     }
   },
@@ -86,10 +74,14 @@
       "$ref": "#/definitions/SystemInformationData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/system_information.json
+++ b/schema/system_information.json
@@ -80,8 +80,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/system_information.json
+++ b/schema/system_information.json
@@ -1,0 +1,100 @@
+{
+  "definitions": {
+    "SystemInformationData": {
+      "type": "object",
+      "properties": {
+        "system_id": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "short_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operator": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "purchase_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "phone_number": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "email": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "license_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "system_id",
+        "language",
+        "name",
+        "short_name",
+        "operator",
+        "url",
+        "purchase_url",
+        "start_date",
+        "phone_number",
+        "email",
+        "timezone",
+        "license_url"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SystemInformationData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_pricing_plans.json
+++ b/schema/system_pricing_plans.json
@@ -1,0 +1,76 @@
+{
+  "definitions": {
+    "PricingPlan": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "plan_id": {
+          "type": "string"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "currency": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "is_taxable": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "plan_id",
+        "url",
+        "name",
+        "currency",
+        "price",
+        "is_taxable",
+        "description"
+      ]
+    },
+    "SystemPricingPlansData": {
+      "type": "object",
+      "properties": {
+        "plans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PricingPlan"
+          }
+        }
+      },
+      "required": [
+        "plans"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SystemPricingPlansData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_pricing_plans.json
+++ b/schema/system_pricing_plans.json
@@ -79,8 +79,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [

--- a/schema/system_pricing_plans.json
+++ b/schema/system_pricing_plans.json
@@ -1,39 +1,47 @@
 {
+  "description": "Describes the system pricing.",
   "definitions": {
     "PricingPlan": {
+      "description": "A plan object.",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "plan_id": {
+          "description": "A unique identifier for this plan in the system",
           "type": "string"
         },
         "url": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "A fully qualified URL where the customer can learn more about this particular scheme",
+          "type": "string",
+          "format": "uri"
         },
         "name": {
+          "description": "Name of this pricing scheme",
           "type": "string"
         },
         "currency": {
+          "description": "Currency this pricing is in (ISO 4217 code: http://en.wikipedia.org/wiki/ISO_4217)",
           "type": "string"
         },
         "price": {
+          "description": "Fee for this pricing scheme. This should be in the base unit as defined by the ISO 4217 currency code with the appropriate number of decimal places and omitting the currency symbol. e.g. if the price is in US Dollars the price would be 9.95",
           "type": "number"
         },
         "is_taxable": {
-          "type": "boolean"
+          "description": "1/0 value:\n        0 indicates that no additional tax will be added (either because tax is not charged, or because it is included)\n        1 indicates that tax will be added to the base price",
+          "type": "integer",
+          "minimum": 0.0,
+          "maximum": 1.0
         },
         "description": {
+          "description": "Text field describing the particular pricing plan in human readable terms.  This should include the duration, price, conditions, etc. that the publisher would like users to see. This is intended to be a human-readable description and should not be used for automatic calculations",
           "type": "string"
         }
       },
       "required": [
         "plan_id",
-        "url",
         "name",
         "currency",
         "price",
@@ -42,13 +50,16 @@
       ]
     },
     "SystemPricingPlansData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "plans": {
+          "description": "Array of any number of plan objects.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PricingPlan"
-          }
+          },
+          "minItems": 0
         }
       },
       "required": [
@@ -62,10 +73,14 @@
       "$ref": "#/definitions/SystemPricingPlansData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/system_regions.json
+++ b/schema/system_regions.json
@@ -1,0 +1,53 @@
+{
+  "definitions": {
+    "Region": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "region_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "region_id",
+        "name"
+      ]
+    },
+    "SystemRegionsData": {
+      "type": "object",
+      "properties": {
+        "regions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Region"
+          }
+        }
+      },
+      "required": [
+        "regions"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SystemRegionsData"
+    },
+    "last_updated": {
+      "type": "integer"
+    },
+    "ttl": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "data",
+    "last_updated",
+    "ttl"
+  ]
+}

--- a/schema/system_regions.json
+++ b/schema/system_regions.json
@@ -1,15 +1,19 @@
 {
+  "description": "Describes the regions the system is broken up into.",
   "definitions": {
     "Region": {
+      "description": "A region object.",
       "type": [
         "object",
         "null"
       ],
       "properties": {
         "region_id": {
+          "description": "Unique identifier for the region",
           "type": "string"
         },
         "name": {
+          "description": "Public name for this region",
           "type": "string"
         }
       },
@@ -19,13 +23,16 @@
       ]
     },
     "SystemRegionsData": {
+      "description": "Object containing the data fields for this response",
       "type": "object",
       "properties": {
         "regions": {
+          "description": "Array of region objects",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Region"
-          }
+          },
+          "minItems": 0
         }
       },
       "required": [
@@ -39,10 +46,14 @@
       "$ref": "#/definitions/SystemRegionsData"
     },
     "last_updated": {
+      "description": "Integer POSIX timestamp indicating the last time the data in this feed was updated",
       "type": "integer"
     },
     "ttl": {
-      "type": "integer"
+      "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": "Infinity"
     }
   },
   "required": [

--- a/schema/system_regions.json
+++ b/schema/system_regions.json
@@ -52,8 +52,7 @@
     "ttl": {
       "description": "Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
       "type": "integer",
-      "minimum": 0.0,
-      "maximum": "Infinity"
+      "minimum": 0.0
     }
   },
   "required": [


### PR DESCRIPTION
I'm working on integrating with GBFS feeds and am building a .NET client API to interact with GFBS data. I noticed that JSON Schema files were requested in issue #37, so I figured I'd generate them from the models I created for my client.

For reference, here's the code that I used to generate the JSON schemas: https://github.com/syncromatics/gbfs.net/pull/2

I didn't see a contributors' guide, so please let me know if changes are needed in this PR.