### PR TITLE
Add "num_usable_bikes" and "num_usable_spaces" to station_status.json

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -198,6 +198,8 @@ Field Name            | Required  | Defines
 --------------------- | ----------| ----------
 stations              | Yes       | Array that contains one object per station in the system as defined below
 \- station_id          | Yes       | Unique identifier of a station (see station_information.json)
+\- num_usable_bikes    | Yes       | Number of usable bikes at the station. A bike is usable if it's not broken and could be rented if `is_renting` was true.
+\- num_usable_spaces   | Yes       | Number of usable docks at the station. A dock is usable if it's not broken and could receive bikes if `is_returning` was true.
 \- num_bikes_available | Yes       | Number of bikes available for rental
 \- num_bikes_disabled  | Optional  | Number of disabled bikes at the station. Vendors who do not want to publicize the number of disabled bikes or docks in their system can opt to omit station capacity (in station_information), num_bikes_disabled and num_docks_disabled. If station capacity is published then broken docks/bikes can be inferred (though not specifically whether the decreased capacity is a broken bike or dock)
 \- num_docks_available | Yes       | Number of docks accepting bike returns


### PR DESCRIPTION
This change tries to fix the limitation the current spec has, where it's not possible to know how many bikes are there at a station when `is_renting = 0`.

In my opinion, as exposed in issue #94, `is_renting` should be independent to `num_bikes_available`. In the same way, `is_returning` should be independent to `num_docks_available`.

Because changing the spec would break existing clients implementing it, I propose adding `num_usable_bikes` and `num_usable_spaces` to the spec.

These two new fields, in conjunction with `is_renting` and `is_returning`, arguably make `num_bikes_available` and `num_docks_available` redundant, but keeping them guarantees backward compatibility.

What we achieve with this spec change is to know how many bikes and spaces there are in a station regardless of the `is_renting` and `is_returning` flag. 

This allows clients to:
- Keep all the current GBFS functionality, but providing the extra features below. 
- Plan their journeys before the beginning of a station's renting hours. If a station starts renting at 7am, they will be able to see how many usable bikes there are at the station before that time. The current spec would display 0 bikes until 7am.
- Visualize number of bikes in each station on a map, regardless of the renting/returning hours.
