### PR TITLE
Append gbfs.json to auto-discovery URLs

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -22,11 +22,11 @@ CA,BIXI-Montreal,"Montreal, QC",Bixi_MTL,https://www.bixi.com/,https://api-core.
 CA,Mobi Bike Share,"Vancouver, BC",mobi_bikes,https://www.mobibikes.ca/,https://vancouver-gbfs.smoove.pro/gbfs/gbfs.json
 CA,nextbike Canada,"Victoria, CA",nextbike_ca,https://canada.nextbike.net/xx/,https://api.nextbike.net/maps/gbfs/v1/nextbike_ca/gbfs.json
 CA,Sobi Hamilton,Hamilton Ontario,sobi_hamilton,https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
-CA,VeloGo,"Ottawa, ON",velgo,http://velogo.ca/,http://velogo.ca/opendata/gbfs.json/gbfs.json
+CA,VeloGo,"Ottawa, ON",velgo,http://velogo.ca/,http://velogo.ca/opendata/gbfs.json
 CH,nextbike Switzerland,"CH",nextbike_ch,https://www.nextbike.ch/xx/sursee/,https://api.nextbike.net/maps/gbfs/v1/nextbike_ch/gbfs.json
 CY,nextbike Cyprus,"CY",nextbike_cy,https://www.nextbike.com.cy/xx/limassol/,https://api.nextbike.net/maps/gbfs/v1/nextbike_cy/gbfs.json
 CY,Velespeed,"Nicosia, CY",velespeed,https://en.velespeed.net/,https://nicosia.publicbikesystem.net/ube/gbfs/v1/
-CZ,Velonet,"Prague - Brno, CZ",velonet_cz,http://velonet.cz/,http://velonet.cz/opendata/gbfs.json/gbfs.json
+CZ,Velonet,"Prague - Brno, CZ",velonet_cz,http://velonet.cz/,http://velonet.cz/opendata/gbfs.json
 DE,Berlin-Buch Campus,"Berlin-Buch, DE",nextbike_cb,https://www.nextbike.de/xx/berlin-buch/,https://germany.nextbike.net/maps/gbfs/v1/nextbike_cb/gbfs.json
 DE,Deezer nextbike,"Berlin, DE",nextbike_bn,https://www.deezernextbike.de/xx/berlin/,https://deezer.nextbike.net/maps/gbfs/v1/nextbike_bn/gbfs.json
 DE,ebikestation Stuttgart Germany,"DE",nextbike_eg,https://www.e-bike-stationen.de/,https://api.nextbike.net/maps/gbfs/v1/nextbike_eg/gbfs.json

--- a/systems.csv
+++ b/systems.csv
@@ -22,11 +22,11 @@ CA,BIXI-Montreal,"Montreal, QC",Bixi_MTL,https://www.bixi.com/,https://api-core.
 CA,Mobi Bike Share,"Vancouver, BC",mobi_bikes,https://www.mobibikes.ca/,https://vancouver-gbfs.smoove.pro/gbfs/gbfs.json
 CA,nextbike Canada,"Victoria, CA",nextbike_ca,https://canada.nextbike.net/xx/,https://api.nextbike.net/maps/gbfs/v1/nextbike_ca/gbfs.json
 CA,Sobi Hamilton,Hamilton Ontario,sobi_hamilton,https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json
-CA,VeloGo,"Ottawa, ON",velgo,http://velogo.ca/,http://velogo.ca/opendata/gbfs.json
+CA,VeloGo,"Ottawa, ON",velgo,http://velogo.ca/,http://velogo.ca/opendata/gbfs.json/gbfs.json
 CH,nextbike Switzerland,"CH",nextbike_ch,https://www.nextbike.ch/xx/sursee/,https://api.nextbike.net/maps/gbfs/v1/nextbike_ch/gbfs.json
 CY,nextbike Cyprus,"CY",nextbike_cy,https://www.nextbike.com.cy/xx/limassol/,https://api.nextbike.net/maps/gbfs/v1/nextbike_cy/gbfs.json
 CY,Velespeed,"Nicosia, CY",velespeed,https://en.velespeed.net/,https://nicosia.publicbikesystem.net/ube/gbfs/v1/
-CZ,Velonet,"Prague - Brno, CZ",velonet_cz,http://velonet.cz/,http://velonet.cz/opendata/gbfs.json
+CZ,Velonet,"Prague - Brno, CZ",velonet_cz,http://velonet.cz/,http://velonet.cz/opendata/gbfs.json/gbfs.json
 DE,Berlin-Buch Campus,"Berlin-Buch, DE",nextbike_cb,https://www.nextbike.de/xx/berlin-buch/,https://germany.nextbike.net/maps/gbfs/v1/nextbike_cb/gbfs.json
 DE,Deezer nextbike,"Berlin, DE",nextbike_bn,https://www.deezernextbike.de/xx/berlin/,https://deezer.nextbike.net/maps/gbfs/v1/nextbike_bn/gbfs.json
 DE,ebikestation Stuttgart Germany,"DE",nextbike_eg,https://www.e-bike-stationen.de/,https://api.nextbike.net/maps/gbfs/v1/nextbike_eg/gbfs.json
@@ -175,14 +175,14 @@ US,Indy - Pacers Bikeshare,"Indianapolis, IN",bcycle_pacersbikeshare,https://www
 US,Jackson County,"Jackson, MI",bcycle_jacksoncounty,https://jacksoncounty.bcycle.com,https://gbfs.bcycle.com/bcycle_jacksoncounty/gbfs.json
 US,JerseyBike,"US",nextbike_nj,http://www.hudsonbikeshare.com/xx/hoboken/,https://api.nextbike.net/maps/gbfs/v1/nextbike_nj/gbfs.json
 US,Juice,"Orlando, FL",juice_bike_share,https://www.juicebikeshare.com/,https://www.juicebikeshare.com/opendata/gbfs.json
-US,JUMP Austin,"Austin, TX",jump_austin,https://jumpbikes.com/,https://atx.jumpbikes.com/opendata
-US,JUMP Chicago,"Chicago, IL",jump_chicago,https://jumpbikes.com/,https://chi.jumpbikes.com/opendata
+US,JUMP Austin,"Austin, TX",jump_austin,https://jumpbikes.com/,https://atx.jumpbikes.com/opendata/gbfs.json
+US,JUMP Chicago,"Chicago, IL",jump_chicago,https://jumpbikes.com/,https://chi.jumpbikes.com/opendata/gbfs.json
 US,JUMP DC,"Washington, DC",jump_dc,https://jumpbikes.com/,https://dc.jumpmobility.com/opendata/gbfs.json
-US,JUMP Denver,"Denver, CO",jump_denver,https://jumpbikes.com/,https://den.jumpbikes.com/opendata
-US,JUMP NYC,"NYC, NY",jump_nyc,https://jumpbikes.com/,https://nyc.jumpbikes.com/opendata
-US,JUMP Sacramento,"Sacramento, CA",jump_sacramento,https://jumpbikes.com/,https://sac.jumpbikes.com/opendata
-US,JUMP SF,"San Francisco, CA",jump_sf,https://jumpbikes.com/,https://sf.jumpbikes.com/opendata
-US,JUMP SC,"Santa Cruz, CA",jump_dc,https://jumpbikes.com/,https://sc.jumpbikes.com/opendata
+US,JUMP Denver,"Denver, CO",jump_denver,https://jumpbikes.com/,https://den.jumpbikes.com/opendata/gbfs.json
+US,JUMP NYC,"NYC, NY",jump_nyc,https://jumpbikes.com/,https://nyc.jumpbikes.com/opendata/gbfs.json
+US,JUMP Sacramento,"Sacramento, CA",jump_sacramento,https://jumpbikes.com/,https://sac.jumpbikes.com/opendata/gbfs.json
+US,JUMP SF,"San Francisco, CA",jump_sf,https://jumpbikes.com/,https://sf.jumpbikes.com/opendata/gbfs.json
+US,JUMP SC,"Santa Cruz, CA",jump_dc,https://jumpbikes.com/,https://sc.jumpbikes.com/opendata/gbfs.json
 US,Kansas City B-cycle,"Kansas City, MO",bcycle_kc,https://kc.bcycle.com,https://gbfs.bcycle.com/bcycle_kc/gbfs.json
 US,Las Vegas,"Las Vegas, NV",bcycle_rtcbikeshare,https://rtcbikeshare.bcycle.com,https://gbfs.bcycle.com/bcycle_rtcbikeshare/gbfs.json
 US,Link Dayton Bike Share,"Dayton, OH",bcycle_linkdayton,https://www.linkdayton.org,https://gbfs.bcycle.com/bcycle_linkdayton/gbfs.json


### PR DESCRIPTION
Fixes some JUMP systems' auto-discovery URLs to link to the actual JSON data.