### PR TITLE
Remove JUICE (Orlando, FL)

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -180,7 +180,6 @@ US,Indego,"Philadelphia, PA",bcycle_indego,https://www.rideindego.com,https://gb
 US,Indy - Pacers Bikeshare,"Indianapolis, IN",bcycle_pacersbikeshare,https://www.pacersbikeshare.org,https://gbfs.bcycle.com/bcycle_pacersbikeshare/gbfs.json
 US,Jackson County,"Jackson, MI",bcycle_jacksoncounty,https://jacksoncounty.bcycle.com,https://gbfs.bcycle.com/bcycle_jacksoncounty/gbfs.json
 US,JerseyBike,"US",nextbike_nj,https://www.hudsonbikeshare.com/xx/hoboken/,https://gbfs.nextbike.net/maps/gbfs/v1/nextbike_nj/gbfs.json
-US,Juice,"Orlando, FL",juice_bike_share,https://www.juicebikeshare.com/,https://www.juicebikeshare.com/opendata/gbfs.json
 US,JUMP Austin,"Austin, TX",jump_austin,https://jump.com/,https://atx.jumpbikes.com/opendata/gbfs.json
 US,JUMP Chicago,"Chicago, IL",jump_chicago,https://jump.com/,https://chi.jumpbikes.com/opendata/gbfs.json
 US,JUMP DC,"Washington, DC",jump_dc,https://jump.com/,https://dc.jumpmobility.com/opendata/gbfs.json


### PR DESCRIPTION
Old JUICE URL redirects you to HOPR. Discovered the following new feeds that could be added for HOPR:
HOPR Freemont : https://gbfs.hopr.city/api/gbfs/16/
HOPR Bogata: https://gbfs.hopr.city/api/gbfs/15/
HOPR Vancouver: https://gbfs.hopr.city/api/gbfs/13/
HOPR Orlando: https://gbfs.hopr.city/api/gbfs/12/
HOPR Miami: https://gbfs.hopr.city/api/gbfs/11/
HOPR Los Angeles: https://gbfs.hopr.city/api/gbfs/10/
HOPR Tampa: https://gbfs.hopr.city/api/gbfs/8/
HOPR Ottawa: https://gbfs.hopr.city/api/gbfs/6/
HOPR Santa Barbara: https://gbfs.hopr.city/api/gbfs/5/
HOPR Chicago: https://gbfs.hopr.city/api/gbfs/3/