### PR TITLE
Proposal: Geofencing, virtual station, and dockless support

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -237,8 +237,8 @@ stations                | Yes       | Array that contains one object per station
 \- station_id           | Yes       | Unique identifier of a station. See [Field Definitions](#field-definitions) above for ID field requirements
 \- name                 | Yes       | Public name of the station
 \- short_name           | No        | Short name or other type of identifier, as used by the data publisher
-\- lat                  | Yes       | The latitude of station. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
-\- lon                  | Yes       | The longitude of station. The field value must be a valid WGS 84 longitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
+\- lat                  | Conditionally required       | The latitude of station. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees. Required if `station_area` is not defined. 
+\- lon                  | Conditionally required       | The longitude of station. The field value must be a valid WGS 84 longitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees. Required if `station_area` is not defined.
 \- address              | Optional  | Valid street number and name where station is located. This field is intended to be an actual address, not a free form text description (see "cross_street" below)
 \- cross_street         | Optional  | Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc.
 \- region_id            | Optional  | ID of the region where station is located (see [system_regions.json](#system_regionsjson))
@@ -246,8 +246,8 @@ stations                | Yes       | Array that contains one object per station
 \- rental_methods       | Optional  | Array of enumerables containing the payment methods accepted at this station. <br />Current valid values (in CAPS) are:<br /><ul><li>KEY _(i.e. operator issued bike key / fob / card)_</li> <li>CREDITCARD</li> <li>PAYPASS</li> <li>APPLEPAY</li> <li>ANDROIDPAY</li> <li>TRANSITCARD</li> <li>ACCOUNTNUMBER</li> <li>PHONE</li> </ul> This list is intended to be as comprehensive at the time of publication as possible but is subject to change, as defined in [File Requirements](#file-requirements) above
 \- capacity             | Optional  | Number of total docking points installed at this station, both available and unavailable
 \- is_virtual_station   | Optional  | 1/0 Boolean- Is this a virtual station? <br /> <ul><li>1 - The station is a location without physical infrastructure, defined by a point (lat/lon) and/or station_area (below).</li> <li>0 - The station consists of physical infrastructure (docks).</li> </ul>
-\- station_area         | Optional  | A GeoJSON multipolygon that describes the area of a virtual station. If station_area is supplied then the record describes a virtual station. If lat/lon and 'station_area' are both defined, the lat/lon is the significant coordinate of the station (e.g. dock facility or valet drop-off and pick up point).
-\- capacity             | Optional  | Non-negative Integer- Number of total docking points installed at this station, both available and unavailable. Empty indicates unlimited capacity.
+\- station_area         | Conditionally required  | A GeoJSON multipolygon that describes the area of a virtual station. If station_area is supplied then the record describes a virtual station. If lat/lon and 'station_area' are both defined, the lat/lon is the significant coordinate of the station (e.g. dock facility or valet drop-off and pick up point). Required if `lat` and `lon` are not provided.
+\- capacity             | Optional  | Number of total docking points installed at this station, both available and unavailable. Empty indicates unlimited capacity.
 \- vehicle_capacity     | Optional  | _*"vehicle_capacity" depends on passage of the [vehicle_types proposal](https://github.com/NABSA/gbfs/pull/136)._ An object where each key is a vehicle_type_id as described in vehicle_types.json, and the value is a number representing the total number of vehicles of this type that can park within the area defined in the station_area field. If the field station_area is defined, and a particular vehicle type id is not defined in this object, then that vehicle type has unlimited capacity.
 \- valet                | Optional  | 1/0 Boolean- Are there valet services at this station? <br /> <ul><li>1 - Valet services.</li> <li>0 - No valet services [default].</li> </ul>
 
@@ -393,6 +393,69 @@ geofencing_zones{}                   | Yes         | A GeoJSON FeatureCollection
 &emsp;&emsp;- ride_start_allowed     | Yes		   | 1/0 Boolean- Is a ride allowed to start in this zone? <br /> <ul><li>1 - Undocked (“free bike”) ride can start in this zone.</li> <li>0 - Undocked (“free bike”) ride cannot start in this zone.</li> </ul>
 &emsp;&emsp;- ride_end_allowed       | Yes		   | 1/0 Boolean- Is a ride allowed to end in this zone? <br /> <ul><li>1 - Undocked (“free bike”) drop-offs are allowed in this zone.</li> <li>0 - Undocked (“free bike”) drop-offs are not allowed in this zone.</li> </ul>
 &emsp;&emsp;- ride_through_allowed   | Yes		   | 1/0 Boolean- Is a ride allowed to travel through this zone? <br /> <ul><li>1 - Ride can travel through this zone.</li> <li>0 - Ride cannot travel through this zone.</li></ul>
+
+Example:
+```json
+{
+   "last_updated":1434054678,
+   "ttl":0,
+   "version":"2.X",
+   "data":{
+      "geofencing_zones":{
+         "type":"FeatureCollection",
+         "features":[
+            {
+               "type":"Feature",
+               "properties":{
+                  "name":"Downtown Waterfront",
+                  "rules":[
+                     {
+                        "vehicle_type_id":"scooter",
+                        "ride_start_allowed":0,
+                        "ride_end_allowed":0,
+                        "ride_through_allowed":0
+                     }
+                  ]
+               },
+               "geometry":{
+                  "type":"MultiPolygon",
+                  "coordinates":[
+                     [
+                        [
+                           [
+                              -122.66780376434326,
+                              45.49896266763551
+                           ],
+                           [
+                              -122.66810417175292,
+                              45.49824825558575
+                           ],
+                           [
+                              -122.66830801963805,
+                              45.49632305799116
+                           ],
+                           [
+                              -122.66762137413023,
+                              45.49625537406554
+                           ],
+                           [
+                              -122.66721367835997,
+                              45.49924842991741
+                           ],
+                           [
+                              -122.66780376434326,
+                              45.49896266763551
+                           ]
+                        ]
+                     ]
+                  ]
+               }
+            }
+         ]
+      }
+   }
+}
+```
 
 ## Possible Future Enhancements
 There are some items that were proposed in an earlier version of this document but which do not fit into the current specification. They are collected here for reference and for possible discussion and inclusion in this or a future version.

--- a/gbfs.md
+++ b/gbfs.md
@@ -245,11 +245,11 @@ stations                | Yes       | Array that contains one object per station
 \- post_code            | Optional  | Postal code where station is located
 \- rental_methods       | Optional  | Array of enumerables containing the payment methods accepted at this station. <br />Current valid values (in CAPS) are:<br /><ul><li>KEY _(i.e. operator issued bike key / fob / card)_</li> <li>CREDITCARD</li> <li>PAYPASS</li> <li>APPLEPAY</li> <li>ANDROIDPAY</li> <li>TRANSITCARD</li> <li>ACCOUNTNUMBER</li> <li>PHONE</li> </ul> This list is intended to be as comprehensive at the time of publication as possible but is subject to change, as defined in [File Requirements](#file-requirements) above
 \- capacity             | Optional  | Number of total docking points installed at this station, both available and unavailable
-\- is_virtual_station   | Optional  | 1/0 Boolean- Is this a virtual station? 1 - The station is a location without physical infrastructure, defined by a point (lat/lon) and/or station_area (below). 0 - The station consists of physical infrastructure (docks).
+\- is_virtual_station   | Optional  | 1/0 Boolean- Is this a virtual station? <br /> <ul><li>1 - The station is a location without physical infrastructure, defined by a point (lat/lon) and/or station_area (below).</li> <li>0 - The station consists of physical infrastructure (docks).</li> </ul>
 \- station_area         | Optional  | A GeoJSON multipolygon that describes the area of a virtual station. If station_area is supplied then the record describes a virtual station. If lat/lon and 'station_area' are both defined, the lat/lon is the significant coordinate of the station (e.g. dock facility or valet drop-off and pick up point).
 \- capacity             | Optional  | Non-negative Integer- Number of total docking points installed at this station, both available and unavailable. Empty indicates unlimited capacity.
 \- vehicle_capacity     | Optional  | _*"vehicle_capacity" depends on passage of the [vehicle_types proposal](https://github.com/NABSA/gbfs/pull/136)._ An object where each key is a vehicle_type_id as described in vehicle_types.json, and the value is a number representing the total number of vehicles of this type that can park within the area defined in the station_area field. If the field station_area is defined, and a particular vehicle type id is not defined in this object, then that vehicle type has unlimited capacity.
-\- valet                | Optional  | 1/0 Boolean- Are there valet services at this station? 1 - Valet services. 0 - No valet services [default].
+\- valet                | Optional  | 1/0 Boolean- Are there valet services at this station? <br /> <ul><li>1 - Valet services.</li> <li>0 - No valet services [default].</li> </ul>
 
 ### station_status.json
 
@@ -390,9 +390,9 @@ geofencing_zones{}                   | Yes         | A GeoJSON FeatureCollection
 &emsp;- name                         | Optional    | String- Name of the geofencing zone.
 &emsp;- rules[]                      | Optional    | Array that contains one object per rule as defined below. In the event of overlapping or colliding rule, the earlier defined rule (in order of the JSON file) takes precedence.
 &emsp;&emsp;- vehicle_type_id        | Optional    | Array of IDs of vehicle types for which any restrictions should be applied (see vehicle type definitions in [PR #136](https://github.com/NABSA/gbfs/pull/136)). If vehicle_type_ids are not specified, then restrictions apply to all vehicle types.
-&emsp;&emsp;- ride_start_allowed     | Yes		   | 1/0 Boolean- Is a ride allowed to start in this zone? 1 - Undocked (“free bike”) ride can start in this zone. 0 - Undocked (“free bike”) ride cannot start in this zone.
-&emsp;&emsp;- ride_end_allowed       | Yes		   | 1/0 Boolean- Is a ride allowed to end in this zone? 1 - Undocked (“free bike”) drop-offs are allowed in this zone. 0 - Undocked (“free bike”) drop-offs are not allowed in this zone.
-&emsp;&emsp;- ride_through_allowed   | Yes		   | 1/0 Boolean- Is a ride allowed to travel through this zone? 1 - Ride can travel through this zone. 0 - Ride cannot travel through this zone.
+&emsp;&emsp;- ride_start_allowed     | Yes		   | 1/0 Boolean- Is a ride allowed to start in this zone? <br /> <ul><li>1 - Undocked (“free bike”) ride can start in this zone.</li> <li>0 - Undocked (“free bike”) ride cannot start in this zone.</li> </ul>
+&emsp;&emsp;- ride_end_allowed       | Yes		   | 1/0 Boolean- Is a ride allowed to end in this zone? <br /> <ul><li>1 - Undocked (“free bike”) drop-offs are allowed in this zone.</li> <li>0 - Undocked (“free bike”) drop-offs are not allowed in this zone.</li> </ul>
+&emsp;&emsp;- ride_through_allowed   | Yes		   | 1/0 Boolean- Is a ride allowed to travel through this zone? <br /> <ul><li>1 - Ride can travel through this zone.</li> <li>0 - Ride cannot travel through this zone.</li></ul>
 
 ## Possible Future Enhancements
 There are some items that were proposed in an earlier version of this document but which do not fit into the current specification. They are collected here for reference and for possible discussion and inclusion in this or a future version.

--- a/gbfs.md
+++ b/gbfs.md
@@ -20,6 +20,7 @@ This branch and associated pull request is to discuss (a proposal)[https://docs.
     * [system_regions.json](#system_regionsjson)
     * [system_pricing_plans.json](#system_pricing_plansjson)
     * [system_alerts.json](#system_alertsjson)
+    * [geofencing_zones.json](#geofencing_zonesjson)
 * [Possible Future Enhancements](#possible-future-enhancements)
 
 ## Revision History
@@ -64,6 +65,7 @@ system_calendar.json        | Optional                | Describes the days of op
 system_regions.json         | Optional                | Describes the regions the system is broken up into
 system_pricing_plans.json   | Optional                | Describes the system pricing
 system_alerts.json          | Optional                | Describes current system alerts
+geofencing_zones.json       | Optional                | Geofenced zones and their associated rules and attributes.
 
 ## File Requirements
 * All files should be valid JSON
@@ -229,20 +231,25 @@ license_url       | Optional  | A fully qualified URL of a page that defines the
 ### station_information.json
 All stations contained in this list are considered public (ie, can be shown on a map for public use). If there are private stations (such as Capital Bikeshare’s White House station) these should not be exposed here and their status should not be included in station_status.json.
 
-Field Name        | Required  | Defines
-------------------| --------- | ----------
-stations          | Yes       | Array that contains one object per station in the system as defined below
-\- station_id      | Yes       | Unique identifier of a station. See [Field Definitions](#field-definitions) above for ID field requirements
-\- name            | Yes       | Public name of the station
-\- short_name      | No        | Short name or other type of identifier, as used by the data publisher
-\- lat             | Yes       | The latitude of station. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
-\- lon             | Yes       | The longitude of station. The field value must be a valid WGS 84 longitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
-\- address         | Optional  | Valid street number and name where station is located. This field is intended to be an actual address, not a free form text description (see "cross_street" below)
-\- cross_street    | Optional  | Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc.
-\- region_id       | Optional  | ID of the region where station is located (see [system_regions.json](#system_regionsjson))
-\- post_code       | Optional  | Postal code where station is located
-\- rental_methods  | Optional  | Array of enumerables containing the payment methods accepted at this station. <br />Current valid values (in CAPS) are:<br /><ul><li>KEY _(i.e. operator issued bike key / fob / card)_</li> <li>CREDITCARD</li> <li>PAYPASS</li> <li>APPLEPAY</li> <li>ANDROIDPAY</li> <li>TRANSITCARD</li> <li>ACCOUNTNUMBER</li> <li>PHONE</li> </ul> This list is intended to be as comprehensive at the time of publication as possible but is subject to change, as defined in [File Requirements](#file-requirements) above
-\- capacity        | Optional  | Number of total docking points installed at this station, both available and unavailable
+Field Name              | Required  | Defines
+----------------------  | --------- | ----------
+stations                | Yes       | Array that contains one object per station in the system as defined below
+\- station_id           | Yes       | Unique identifier of a station. See [Field Definitions](#field-definitions) above for ID field requirements
+\- name                 | Yes       | Public name of the station
+\- short_name           | No        | Short name or other type of identifier, as used by the data publisher
+\- lat                  | Yes       | The latitude of station. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
+\- lon                  | Yes       | The longitude of station. The field value must be a valid WGS 84 longitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
+\- address              | Optional  | Valid street number and name where station is located. This field is intended to be an actual address, not a free form text description (see "cross_street" below)
+\- cross_street         | Optional  | Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc.
+\- region_id            | Optional  | ID of the region where station is located (see [system_regions.json](#system_regionsjson))
+\- post_code            | Optional  | Postal code where station is located
+\- rental_methods       | Optional  | Array of enumerables containing the payment methods accepted at this station. <br />Current valid values (in CAPS) are:<br /><ul><li>KEY _(i.e. operator issued bike key / fob / card)_</li> <li>CREDITCARD</li> <li>PAYPASS</li> <li>APPLEPAY</li> <li>ANDROIDPAY</li> <li>TRANSITCARD</li> <li>ACCOUNTNUMBER</li> <li>PHONE</li> </ul> This list is intended to be as comprehensive at the time of publication as possible but is subject to change, as defined in [File Requirements](#file-requirements) above
+\- capacity             | Optional  | Number of total docking points installed at this station, both available and unavailable
+\- is_virtual_station   | Optional  | 1/0 Boolean- Is this a virtual station? 1 - The station is a location without physical infrastructure, defined by a point (lat/lon) and/or station_area (below). 0 - The station consists of physical infrastructure (docks).
+\- station_area         | Optional  | A GeoJSON multipolygon that describes the area of a virtual station. If station_area is supplied then the record describes a virtual station. If lat/lon and 'station_area' are both defined, the lat/lon is the significant coordinate of the station (e.g. dock facility or valet drop-off and pick up point).
+\- capacity             | Optional  | Non-negative Integer- Number of total docking points installed at this station, both available and unavailable. Empty indicates unlimited capacity.
+\- vehicle_capacity     | Optional  | _*"vehicle_capacity" depends on passage of the [vehicle_types proposal](https://github.com/NABSA/gbfs/pull/136)._ An object where each key is a vehicle_type_id as described in vehicle_types.json, and the value is a number representing the total number of vehicles of this type that can park within the area defined in the station_area field. If the field station_area is defined, and a particular vehicle type id is not defined in this object, then that vehicle type has unlimited capacity.
+\- valet                | Optional  | 1/0 Boolean- Are there valet services at this station? 1 - Valet services. 0 - No valet services [default].
 
 ### station_status.json
 
@@ -262,14 +269,15 @@ stations              | Yes       | Array that contains one object per station i
 ### free_bike_status.json
 Describes bikes that are not at a station and are not currently in the middle of an active ride.
 
-Field Name        | Required  | Defines
-------------------| ----------| ----------
-bikes             | Yes       | Array that contains one object per bike that is currently docked/stopped outside of the system as defined below
-\- bike_id         | Yes       | Unique identifier of a bike
-\- lat             | Yes       | Latitude of the bike. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
-\- lon             | Yes       | Longitude of the bike. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
-\- is_reserved     | Yes       | 1/0 value - is the bike currently reserved for someone else
-\- is_disabled     | Yes       | 1/0 value - is the bike currently disabled (broken)
+Field Name        | Required                  | Defines
+------------------| ------------------------  | ----------
+bikes             | Yes                       | Array that contains one object per bike that is currently docked/stopped outside of the system as defined below
+\- bike_id        | Yes                       | Unique identifier of a bike
+\- lat            | Yes                       | Latitude of the bike. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
+\- lon            | Yes                       | Longitude of the bike. The field value must be a valid WGS 84 latitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
+\- is_reserved    | Yes                       | 1/0 value - is the bike currently reserved for someone else
+\- is_disabled    | Yes                       | 1/0 value - is the bike currently disabled (broken)
+\- system_id      | Conditionally required    | ID- Refers to the system_id field in system_information.json. Required in the case of feeds that specify free (undocked) bikes and define systems in system_information.json.
 
 ### system_hours.json
 Describes the system hours of operation. A JSON array of hours defined as follows:
@@ -369,6 +377,22 @@ alerts            | Yes         | Array - alert objects each indicating a separa
 \- summary         | Yes         | String - A short summary of this alert to be displayed to the customer
 \- description     | Optional    | String - Detailed text description of the alert
 \- last_updated    | Optional    | Integer POSIX timestamp indicating the last time the info for the particular alert was updated
+
+### geofencing_zones.json
+This file is optional. All fields indicated as “Required” are only required if geofencing_zones.json is supplied.
+
+Field Name                           | Required    | Defines
+-----------------------------------  | ------------| ----------
+geofencing_zones{}                   | Yes         | A GeoJSON FeatureCollection (as described by the IETF [RFC 7946](https://tools.ietf.org/html/rfc7946#section-3.3)). Each geofenced zone and its associated rules and attributes is described as an object within the array of features, as follows.
+\- type                              | Yes         | String- “Feature” (as per IETF [RFC 7946](https://tools.ietf.org/html/rfc7946#section-3.3)).
+\- geometry                          | Yes         | A GeoJSON Multipolygon that describes where rides might not be able to start, end, go through, or have other limitations. A clockwise arrangement of points defines the area enclosed by the polygon, while a counterclockwise order defines the area outside the polygon [(right-hand rule)](https://tools.ietf.org/html/rfc7946#section-3.1.6). All geofencing zones contained in this list are public.
+\- properties{}                      | Yes		   | As defined below, describes travel allowances and limitations.
+&emsp;- name                         | Optional    | String- Name of the geofencing zone.
+&emsp;- rules[]                      | Optional    | Array that contains one object per rule as defined below. In the event of overlapping or colliding rule, the earlier defined rule (in order of the JSON file) takes precedence.
+&emsp;&emsp;- vehicle_type_id        | Optional    | Array of IDs of vehicle types for which any restrictions should be applied (see vehicle type definitions in [PR #136](https://github.com/NABSA/gbfs/pull/136)). If vehicle_type_ids are not specified, then restrictions apply to all vehicle types.
+&emsp;&emsp;- ride_start_allowed     | Yes		   | 1/0 Boolean- Is a ride allowed to start in this zone? 1 - Undocked (“free bike”) ride can start in this zone. 0 - Undocked (“free bike”) ride cannot start in this zone.
+&emsp;&emsp;- ride_end_allowed       | Yes		   | 1/0 Boolean- Is a ride allowed to end in this zone? 1 - Undocked (“free bike”) drop-offs are allowed in this zone. 0 - Undocked (“free bike”) drop-offs are not allowed in this zone.
+&emsp;&emsp;- ride_through_allowed   | Yes		   | 1/0 Boolean- Is a ride allowed to travel through this zone? 1 - Ride can travel through this zone. 0 - Ride cannot travel through this zone.
 
 ## Possible Future Enhancements
 There are some items that were proposed in an earlier version of this document but which do not fit into the current specification. They are collected here for reference and for possible discussion and inclusion in this or a future version.

--- a/gbfs.md
+++ b/gbfs.md
@@ -1,6 +1,8 @@
 # General Bikeshare Feed Specification (GBFS)
 This document explains the types of files and data that comprise the General Bikeshare Feed Specification (GBFS) and defines the fields used in all of those files.
 
+This branch and associated pull request is to discuss (a proposal)[https://docs.google.com/document/d/1po4tlv5p7jXB6KQYohLAIS0qKJfxI1e-EH3JjiyUWoc/edit] to add support for dockless, geofencing, and virtual stations.
+
 ## Table of Contents
 
 * [Revision History](#revision-history)


### PR DESCRIPTION
This pull request is to discuss **[a proposal (Google Doc) -- v2, revised Oct 30](https://docs.google.com/document/d/1XgPgPL00W5BY_RdoduTah6Vn7VCT0EvRzr7KOi3vgCk/edit)** to add support for dockless, geofencing, and virtual stations. Please make comments in this thread or directly in the Google Doc. Once we have arrived at a proposal that is an implementation candidate (at least one producer and consumer say they plan to implement), then @MobilityData will edit the final proposal text and commit it to this pull request.

## Proposal summary
This proposal extends GBFS (General Bikesharing Feed Spec) to add support for:
- Dockless systems: free standing vehicles (e.g. bicycles, e-bikes, scooters) that can be rented on the street, outside the bounds of a physical station.
- Virtual stations where vehicles can be deposited or retrieved from a bounded area, but no physical dock infrastructure is installed.
- Geofenced areas with rules for allowed and disallowed travel and speeds.

The specific changes are:
- Add geofencing_zones.json (as a GeoJSON FeatureCollection) to define geofencing zones and allowed and disallowed travel.
- Extend station_information.json to allow description of the area of a virtual station.
- Revise station_information.json to describe stations with unlimited capacity.

An earlier version of the proposal, **[v1 (Google Doc)](https://docs.google.com/document/d/1po4tlv5p7jXB6KQYohLAIS0qKJfxI1e-EH3JjiyUWoc/edit)** included additional elements (discarded because there were no interested implementers):

- ~~Extend the proposed vehicle_types.json (PR #136) to declare whether a vehicle can be left in a dock or freestanding or both.~~
- ~~Extend system_hours.json to describe hours during which actions specified in geofencing_zone_information.json can occur.~~