### PR TITLE
Proposal: Add feed_contact_email field to system_information.json

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -170,6 +170,7 @@ purchase_url      | Optional  | A fully qualified URL where a customer can purch
 start_date        | Optional  | String in the form YYYY-MM-DD representing the date that the system began operations
 phone_number      | Optional  | A single voice telephone number for the specified system. This field is a string value that presents the telephone number as typical for the system's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, Capital Bikeshare’s  "877-430-BIKE") is permitted, but the field must not contain any other descriptive text
 email             | Optional  | A single contact email address for customers to address questions about the system
+technical_email   | Optional  | A single contact email address for consumers of this feed to report technical issues
 timezone          | Yes       | The time zone where the system is located. Time zone names never contain the space character but may contain an underscore. Please refer to the "TZ" value in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid values
 license_url       | Optional  | A fully qualified URL of a page that defines the license terms for the GBFS data for this system, as well as any other license terms the system would like to define (including the use of corporate trademarks, etc)
 

--- a/gbfs.md
+++ b/gbfs.md
@@ -170,7 +170,7 @@ purchase_url      | Optional  | A fully qualified URL where a customer can purch
 start_date        | Optional  | String in the form YYYY-MM-DD representing the date that the system began operations
 phone_number      | Optional  | A single voice telephone number for the specified system. This field is a string value that presents the telephone number as typical for the system's service area. It can and should contain punctuation marks to group the digits of the number. Dialable text (for example, Capital Bikeshare’s  "877-430-BIKE") is permitted, but the field must not contain any other descriptive text
 email             | Optional  | A single contact email address for customers to address questions about the system
-technical_email   | Optional  | A single contact email address for consumers of this feed to report technical issues
+feed_contact_email| Optional  | A single contact email address for consumers of this feed to report technical issues
 timezone          | Yes       | The time zone where the system is located. Time zone names never contain the space character but may contain an underscore. Please refer to the "TZ" value in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid values
 license_url       | Optional  | A fully qualified URL of a page that defines the license terms for the GBFS data for this system, as well as any other license terms the system would like to define (including the use of corporate trademarks, etc)
 


### PR DESCRIPTION
#### Issue

Currently as a consumer of a feed, you have no real way to contact the operator of that feed. The `email` attribute is meant for general support purposes, so doesn't solve this issue. This results in issues being opened on this repository and causes a really painful feedback loop of trying to locate the person who can fix the actual problem. This is particularly relevant as we've been discussing more systematic validation tools for feeds in systems.csv in the GBFS workshop.

#### Solution

Non-breaking, adds an optional `technical_email` property to `system_information.json` where providers can specify where to send bug/validation/etc. reports.

#### Feedback needed

- Open to changing the actual property name, but this was the clearest I could come up with.
- Should `email` be renamed to `support_email` to clarify it's purpose?
- Should this be required and released as a breaking change?
- Is this useful for feed consumers?
- Is this easy for operators to add, or is it too much of a burden?