### PR TITLE
system_regions.json: deprecation candidate

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -15,7 +15,6 @@ This document explains the types of files and data that comprise the General Bik
     * [free_bike_status.json](#free_bike_statusjson)
     * [system_hours.json](#system_hoursjson)
     * [system_calendar.json](#system_calendarjson)
-    * [system_regions.json](#system_regionsjson)
     * [system_pricing_plans.json](#system_pricing_plansjson)
     * [system_alerts.json](#system_alertsjson)
 * [Possible Future Enhancements](#possible-future-enhancements)
@@ -187,7 +186,6 @@ stations          | Yes       | Array that contains one object per station in th
 \- lon             | Yes       | The longitude of station. The field value must be a valid WGS 84 longitude in decimal degrees format. See: http://en.wikipedia.org/wiki/World_Geodetic_System, https://en.wikipedia.org/wiki/Decimal_degrees
 \- address         | Optional  | Valid street number and name where station is located. This field is intended to be an actual address, not a free form text description (see "cross_street" below)
 \- cross_street    | Optional  | Cross street of where the station is located. This field is intended to be a descriptive field for human consumption. In cities, this would be a cross street, but could also be a description of a location in a park, etc.
-\- region_id       | Optional  | ID of the region where station is located (see [system_regions.json](#system_regionsjson))
 \- post_code       | Optional  | Postal code where station is located
 \- rental_methods  | Optional  | Array of enumerables containing the payment methods accepted at this station. <br />Current valid values (in CAPS) are:<br /><ul><li>KEY _(i.e. operator issued bike key / fob / card)_</li> <li>CREDITCARD</li> <li>PAYPASS</li> <li>APPLEPAY</li> <li>ANDROIDPAY</li> <li>TRANSITCARD</li> <li>ACCOUNTNUMBER</li> <li>PHONE</li> </ul> This list is intended to be as comprehensive at the time of publication as possible but is subject to change, as defined in [File Requirements](#file-requirements) above
 \- capacity        | Optional  | Number of total docking points installed at this station, both available and unavailable
@@ -273,16 +271,6 @@ calendars           | Yes       | Array of year objects describing the system op
 \- end_day           | Yes       | Ending day for the system operations (1-31)
 \- end_year          | Optional  | Ending year for the system operations
 
-
-### system_regions.json
-Describe regions for a system that is broken up by geographic or political region. It is defined as a separate feed to allow for additional region metadata (such as shape definitions).
-
-Field Name        | Required  | Defines
-------------------| ----------| ----------
-regions           | Yes       | Array of region objects as defined below
-\- region_id       | Yes       | Unique identifier for the region
-\- name           | Yes       | Public name for this region
-
 ### system_pricing_plans.json
 Describe pricing for the system. This scheme does not currently factor in lost bike fees as it seems outside of the scope of this specification, but they could be added. It is an array of pricing objects defined as follows:
 
@@ -310,8 +298,7 @@ alerts            | Yes         | Array - alert objects each indicating a separa
 \- times           | Optional    | Array of hashes with the keys "start" and "end" indicating when the alert is in effect (e.g. when the system or station is actually closed, or when it is scheduled to be moved). If this array is omitted then the alert should be displayed as long as it is in the feed.
 &emsp;- start     | Yes         | Integer POSIX timestamp - required if container "times" key is present
 &emsp;- end       | Optional    | Integer POSIX timestamp - if there is currently no end time planned for the alert, this key can be omitted indicating that there is no currently scheduled end time for the alert
-\- station_ids     | Optional    | Array of strings - If this is an alert that affects one or more stations, include their ids, otherwise omit this field. If both station_ids and region_ids are omitted, assume this alert affects the entire system
-\- region_ids      | Optional    | Array of strings - If this system has regions, and if this alert only affects certain regions, include their ids, otherwise, omit this field. If both station_ids and region_ids are omitted, assume this alert affects the entire system
+\- station_ids     | Optional    | Array of strings - If this is an alert that affects one or more stations, include their ids, otherwise omit this field. If station_ids are omitted, assume this alert affects the entire system
 \- url             | Optional    | String - URL where the customer can learn more information about this alert, if there is one
 \- summary         | Yes         | String - A short summary of this alert to be displayed to the customer
 \- description     | Optional    | String - Detailed text description of the alert


### PR DESCRIPTION
system_regions.json is currently optional.

At the GBFS Developers Workshop last week, there was only one known instance of a feed that provides system_regions.json, ([Capital Bikeshare](https://gbfs.capitalbikeshare.com/gbfs/gbfs.json)). It is not known how or if this data is being used.

**This pull request is to discuss deprecation candidacy for system_regions.json.** Is this data being used by applications? If not, should we remove system_regions.json?