### PR TITLE
Additions and modifications to inventory of past, current and upcoming versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,22 @@ The specification has been designed with the following concepts in mind:
 
 The data in the specification contained in this document is intended for consumption by clients intending to provide real-time (or semi-real-time) transit advice and is designed as such.
 
-## Read the spec
-* [v1.0](https://github.com/NABSA/gbfs/blob/df473ca4adbff982d67b50ac00b625191591d8f8/gbfs.md)
-* [v1.1: MINOR Release Candidate](https://github.com/NABSA/gbfs/blob/master/gbfs.md)
+## Read the spec & version history
+* **[v1.0: Current Version](https://github.com/NABSA/gbfs/blob/df473ca4adbff982d67b50ac00b625191591d8f8/gbfs.md)**
+  * 2019 December 20 - GBFS copyright [transfered to NABSA](https://github.com/NABSA/gbfs/commit/b1260b9c59eeff810a62e0aedc72ce1d4fb8f3ab)
+  * 2015 November 05 - GBFS V1.0 Adopted by NABSA board - [Original draft spec in a Google doc](https://docs.google.com/document/d/1BQPZCKpem4-n6lUQDD4Mi8E5hNZ0-lhY62IVtWuyhec/edit#heading=h.ic7i1m4gcev7) (reference only)
+  * 2015 August - Latest changes incorporated and name change to GBFS (comments from Motivate, 8D, others)
+  * 2015 June - Proposed refinements (prepared by Jesse Chan-Norris on behalf of Motivate)
+  * 2015 January - NABSA Draft (prepared by Mitch Vars)
+* **[v1.1: MINOR Release Candidate](https://github.com/NABSA/gbfs/blob/master/gbfs.md)**
   * #25 - Add deep links for iOS, Android, and web apps
   * #181 - Add feed\_contact\_email field to system\_information.json
   * #188 - GBFS documentation versioning and and feed conformance
-* [v2.0: MAJOR Release Candidate](https://github.com/NABSA/gbfs/labels/v2.0)
+* **[v2.0: MAJOR Release Candidate](https://github.com/NABSA/gbfs/labels/v2.0)**
   * #182 - Require license\_url, add attribution fields PR #182 
   * #189 - Require autodiscovery gbfs.json file, define feed names
   * #195 - Clarify num\_bikes\_available and num\_docks\_available
   * #196 - Change boolean from 1/0 to true/false
-
-## Version History
-* 2019 December 20 - GBFS copyright [transfered to NABSA](https://github.com/NABSA/gbfs/commit/b1260b9c59eeff810a62e0aedc72ce1d4fb8f3ab)
-* 2015 November 05 - GBFS V1.0 Adopted by NABSA board - [Original draft spec in a Google doc](https://docs.google.com/document/d/1BQPZCKpem4-n6lUQDD4Mi8E5hNZ0-lhY62IVtWuyhec/edit#heading=h.ic7i1m4gcev7) (reference only)
-* 2015 August - Latest changes incorporated and name change to GBFS (comments from Motivate, 8D, others)
-* 2015 June - Proposed refinements (prepared by Jesse Chan-Norris on behalf of Motivate)
-* 2015 January - NABSA Draft (prepared by Mitch Vars)
 
 ## Overview of the Change Process
 GBFS is an open specification, developed and maintained by the community of producers and consumers of GBFS data.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,23 @@ The specification has been designed with the following concepts in mind:
 The data in the specification contained in this document is intended for consumption by clients intending to provide real-time (or semi-real-time) transit advice and is designed as such.
 
 ## Read the spec
+* [v1.0](https://github.com/NABSA/gbfs/blob/df473ca4adbff982d67b50ac00b625191591d8f8/gbfs.md)
+* [v1.1: MINOR Release Candidate]
+  * #25 - Add deep links for iOS, Android, and web apps
+  * #181 - Add feed\_contact\_email field to system\_information.json
+  * #188 - GBFS documentation versioning and and feed conformance
+* [v2.0: MAJOR Release Candidate](https://github.com/NABSA/gbfs/labels/v2.0)
+  * #182 - Require license\_url, add attribution fields PR #182 
+  * #189 - Require autodiscovery gbfs.json file, define feed names
+  * #195 - Clarify num\_bikes\_available and num\_docks\_available
+  * #196 - Change boolean from 1/0 to true/false
 
-* [Current spec](gbfs.md)
-* [Original draft spec in a Google doc](https://docs.google.com/document/d/1BQPZCKpem4-n6lUQDD4Mi8E5hNZ0-lhY62IVtWuyhec/edit#heading=h.ic7i1m4gcev7) (reference only)
+## Version History
+* 2019 December 20 - GBFS copyright [transfered to NABSA](https://github.com/NABSA/gbfs/commit/b1260b9c59eeff810a62e0aedc72ce1d4fb8f3ab)
+* 2015 November 05 - GBFS V1.0 Adopted by NABSA board - [Original draft spec in a Google doc](https://docs.google.com/document/d/1BQPZCKpem4-n6lUQDD4Mi8E5hNZ0-lhY62IVtWuyhec/edit#heading=h.ic7i1m4gcev7) (reference only)
+* 2015 August - Latest changes incorporated and name change to GBFS (comments from Motivate, 8D, others)
+* 2015 June - Proposed refinements (prepared by Jesse Chan-Norris on behalf of Motivate)
+* 2015 January - NABSA Draft (prepared by Mitch Vars)
 
 ## Overview of the Change Process
 GBFS is an open specification, developed and maintained by the community of producers and consumers of GBFS data.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The data in the specification contained in this document is intended for consump
 
 ## Read the spec
 * [v1.0](https://github.com/NABSA/gbfs/blob/df473ca4adbff982d67b50ac00b625191591d8f8/gbfs.md)
-* [v1.1: MINOR Release Candidate]
+* [v1.1: MINOR Release Candidate](https://github.com/NABSA/gbfs/blob/master/gbfs.md)
   * #25 - Add deep links for iOS, Android, and web apps
   * #181 - Add feed\_contact\_email field to system\_information.json
   * #188 - GBFS documentation versioning and and feed conformance

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ The data in the specification contained in this document is intended for consump
   * 2015 June - Proposed refinements (prepared by Jesse Chan-Norris on behalf of Motivate)
   * 2015 January - NABSA Draft (prepared by Mitch Vars)
 * **[v1.1: MINOR Release Candidate](https://github.com/NABSA/gbfs/blob/master/gbfs.md)**
-  * #25 - Add deep links for iOS, Android, and web apps
-  * #181 - Add feed\_contact\_email field to system\_information.json
-  * #188 - GBFS documentation versioning and and feed conformance
+  * [#25](https://github.com/NABSA/gbfs/pull/25) - Add deep links for iOS, Android, and web apps
+  * [#181](https://github.com/NABSA/gbfs/pull/181) - Add feed\_contact\_email field to system\_information.json
+  * [#188](https://github.com/NABSA/gbfs/pull/188) - GBFS documentation versioning and and feed conformance
 * **[v2.0: MAJOR Release Candidate](https://github.com/NABSA/gbfs/labels/v2.0)**
-  * #182 - Require license\_url, add attribution fields PR #182 
-  * #189 - Require autodiscovery gbfs.json file, define feed names
-  * #195 - Clarify num\_bikes\_available and num\_docks\_available
-  * #196 - Change boolean from 1/0 to true/false
+  * [#182](https://github.com/NABSA/gbfs/pull/182) - Require license\_url, add attribution fields PR #182 
+  * [#189](https://github.com/NABSA/gbfs/pull/189) - Require autodiscovery gbfs.json file, define feed names
+  * [#195](https://github.com/NABSA/gbfs/pull/195) - Clarify num\_bikes\_available and num\_docks\_available
+  * [#196](https://github.com/NABSA/gbfs/pull/196) - Change boolean from 1/0 to true/false
 
 ## Overview of the Change Process
 GBFS is an open specification, developed and maintained by the community of producers and consumers of GBFS data.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The data in the specification contained in this document is intended for consump
   * [#181](https://github.com/NABSA/gbfs/pull/181) - Add feed\_contact\_email field to system\_information.json
   * [#188](https://github.com/NABSA/gbfs/pull/188) - GBFS documentation versioning and and feed conformance
 * **[v2.0: MAJOR Release Candidate](https://github.com/NABSA/gbfs/labels/v2.0)**
-  * [#182](https://github.com/NABSA/gbfs/pull/182) - Require license\_url, add attribution fields PR #182 
+  * [#182](https://github.com/NABSA/gbfs/pull/182) - Require license\_url, add attribution fields 
   * [#189](https://github.com/NABSA/gbfs/pull/189) - Require autodiscovery gbfs.json file, define feed names
   * [#195](https://github.com/NABSA/gbfs/pull/195) - Clarify num\_bikes\_available and num\_docks\_available
   * [#196](https://github.com/NABSA/gbfs/pull/196) - Change boolean from 1/0 to true/false

--- a/gbfs.md
+++ b/gbfs.md
@@ -1,6 +1,9 @@
 # General Bikeshare Feed Specification (GBFS)
 This document explains the types of files and data that comprise the General Bikeshare Feed Specification (GBFS) and defines the fields used in all of those files.
 
+# Reference version
+This documentation refers to **version 1.1**. For past and upcoming versions see the [README](README.md).
+
 ## Table of Contents
 
 * [Revision History](#revision-history)
@@ -21,12 +24,6 @@ This document explains the types of files and data that comprise the General Bik
 * [Deep Links - Analytics and Examples](#Deep-Links)
 * [Possible Future Enhancements](#possible-future-enhancements)
 
-## Revision History
-* 11/05/2015 - GBFS V1.0 Adopted by NABSA board
-* 08/2015 - Latest changes incorporated and name change to GBFS (comments from Motivate, 8D, others)
-* 06/2015 - Proposed refinements (prepared by Jesse Chan-Norris on behalf of Motivate)
-* 01/2015 - NABSA Draft (prepared by Mitch Vars)
-
 ## Introduction
 This specification has been designed with the following concepts in mind:
 
@@ -35,7 +32,7 @@ This specification has been designed with the following concepts in mind:
 
 Historical data, including station details and ride data is to be provided by a more compact specification designed specifically for such archival purposes. The data in the specification contained in this document is intended for consumption by clients intending to provide real-time (or semi-real-time) transit advice and is designed as such.
 
-## Versioning
+## Version endpoints
 The version of the GBFS specification to which a feed conforms is declared in the `version` field in all files. See [Output Format](#output-format).
 
 GBFS Best Practice defines that:
@@ -511,17 +508,6 @@ Note that the Android URI and iOS Universal Link URLs don’t necessarily use th
    },
    ...
 ```
-
-## Possible Future Enhancements
-There are some items that were proposed in an earlier version of this document but which do not fit into the current specification. They are collected here for reference and for possible discussion and inclusion in this or a future version.
-
-* system_information.json
-    * _system_data_ - Removed due to a lack of specificity; if metadata about the location of URLs is required / desired, the proposal is to include this in a separate feed_info.json feed which would contain an array with all of the feeds in addition to other feed information such as a feed version (if necessary)
-    * _equipment_ - Removed due to a lack of specificity behind the intent of this field and a question about the actual relevance to the public
-    * _jurisdictions_ - It is believed that the need for this field is negated by the presence of the system_regions.json feed
-
-* station_status.json
-    * need a way to distinguish between multiple bike types at a station if/when  hybrid systems using e-bikes become available
 
 ## Disclaimers
 

--- a/gbfs.md
+++ b/gbfs.md
@@ -117,7 +117,7 @@ Example:
 {
   "last_updated": 1434054678,
   "ttl": 3600,
-  "version": "1.0",
+  "version": "1.1",
   "data": {
     "name": "Citi Bike",
     "system_id": "citibike_com"
@@ -142,7 +142,7 @@ Example:
 {
   "last_updated": 1434054678,
   "ttl": 0,
-  "version": "1.0",
+  "version": "1.1",
   "data": {
     "en": {
       "feeds": [
@@ -187,7 +187,7 @@ _versions_              | Yes         | Array that contains one object, as defin
 {
   "last_updated": 1434054678,
   "ttl": 0,
-  "version": "1.0",
+  "version": "1.1",
   "data": {
   	"versions":
 		[
@@ -299,7 +299,7 @@ Example:
 {
   "last_updated": 1434054678,
   "ttl": 0,
-  "version": "1.0",
+  "version": "1.1",
   "data": {
     "rental_hours": [
       {

--- a/gbfs.md
+++ b/gbfs.md
@@ -22,7 +22,6 @@ This documentation refers to **version 1.1**. For past and upcoming versions see
     * [system_pricing_plans.json](#system_pricing_plansjson)
     * [system_alerts.json](#system_alertsjson)
 * [Deep Links - Analytics and Examples](#Deep-Links)
-* [Possible Future Enhancements](#possible-future-enhancements)
 
 ## Introduction
 This specification has been designed with the following concepts in mind:


### PR DESCRIPTION
Moving towards full implementation of #188 - GBFS documentation versioning and and feed conformance.

Remaining to do:
- [ ] Establish that feed producers and consumers are supporting v1.1 #25 and #181 
- [ ] Tag v1.1 after this PR is merged
- [ ] Create a MAJOR Release Candidate branch that marks beta/experimental fields