### PR TITLE
Fixing space before quote in systems.csv

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -1,6 +1,6 @@
 Country Code,Name,Location,System ID,URL,Auto-Discovery URL
 AE,ADCB Bikeshare,"Abu Dhabi, AE",ABU,https://www.bikeshare.ae/,https://api-core.bikeshare.ae/gbfs/gbfs.json
-AE,Careem BIKE, "Dubai, AE",careem_bike,https://www.careem.com/en-ae/careem-bike/,https://dubai.publicbikesystem.net/ube/gbfs/v1/gbfs.json
+AE,Careem BIKE,"Dubai, AE",careem_bike,https://www.careem.com/en-ae/careem-bike/,https://dubai.publicbikesystem.net/ube/gbfs/v1/gbfs.json
 AR,Ecobici,"Buenos Aires, AR",bike_buenosaires,https://www.buenosaires.gob.ar/ecobici,https://buenosaires.publicbikesystem.net/ube/gbfs/v1/gbfs.json
 AR,MiBiciTuBici,"Rosario, Santa Fe, AR",biketobike,https://www.mibicitubici.gob.ar/,https://www.mibicitubici.gob.ar/opendata/gbfs.json
 AR,MOVO Buenos Aires,"Buenos Aires, AR",movo_bue,https://movo.me/ar,https://gbfs.movo.me/buenosaires


### PR DESCRIPTION
The last addition broke systems.csv validity. According to the csv spec, you cannot add a space before a quoted column. 

This broke my csv parser on https://idoco.github.io/gbfs-viewer/

![image](https://user-images.githubusercontent.com/5776439/79073508-bb529180-7cef-11ea-9ed5-dd94084f003c.png)
