### PR TITLE
Add Vélib Metropole to systems.csv

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -77,6 +77,7 @@ ES,Lovesharing (Canary Islands),"Lovesharing (Canary Islands), ES",nextbike_ls,h
 ES,Sitycleta (Las Palmas),"Las Palmas de Gran Canaria, ES",nextbike_el,https://www.sitycleta.com/es/laspalmas/,https://gbfs.nextbike.net/maps/gbfs/v1/nextbike_el/gbfs.json
 FR,LE vélo STAR,"Rennes, FR",le_velo_star,https://www.star.fr/le-velo/nos-offres/vls/,https://eu.ftp.opendatasoft.com/star/gbfs/gbfs.json
 FR,Libélo,"Valence, FR",libelo,http://www.citea.info/presentation/?rub_code=92,https://valence.publicbikesystem.net/ube/gbfs/v1/gbfs.json
+FR,Vélib' Metropole,"Paris, FR",Paris,https://www.velib-metropole.fr/, https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/gbfs.json
 FR,Vélivert,"Saint-Etienne, FR",Velivert_FR_Saint-Etienne,https://www.velivert.fr/,https://saint-etienne-gbfs.klervi.net/gbfs/gbfs.json
 FR,Vélocéo,"Vannes, FR",Veloceo_FR_Vannes,https://veloceo.kiceo.fr/,https://vannes-gbfs.klervi.net/gbfs/gbfs.json
 FR,Vélopop,"Avignon, FR","Vélopop_FR_Avignon",https://www.velopop.fr/,https://avignon-gbfs.klervi.net/gbfs/gbfs.json


### PR DESCRIPTION
Adding Paris to `systems.csv`.

Set `System ID` to `Paris` as defined in its [system_information.json](https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/system_information.json). Not sure if this is the correct choice.