### PR TITLE
Adding documentation for type Time

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -103,7 +103,7 @@ system_alerts.json | Optional | Current system alerts.
 * Object - A JSON element consisting of key-value pairs (fields).
 * Boolean - One of two possible values, `true`or `false`. Boolean values must be JSON booleans, not strings (i.e. `true` or `false`, not `"true"` or `"false"`). *(as of v2.0)*
 * Date - Service day in the YYYY-MM-DD format. Example: `2019-09-13` for September 13th, 2019.
-* Time - Service time in the HH:MM:SS format. Example: `21:20:02` or `01:58:00`
+* Time - Service time in the HH:MM:SS format for the time zone indicated in system_information.json (00:00:00 - 47:59:59). Time can stretch up to one additional day in the future to accommodate situations where, for example, a system was open from 11:30pm - 11pm the next day (i.e. 23:30:00-47:00:00).
 * Email - An email address. Example: `example@example.com`
 * Enum (Enumerable values) - An option from a set of predefined constants in the "Defines" column.
 Example: The `rental_methods` field contains values `CREDITCARD`, `PAYPASS`, etc...

--- a/gbfs.md
+++ b/gbfs.md
@@ -103,6 +103,7 @@ system_alerts.json | Optional | Current system alerts.
 * Object - A JSON element consisting of key-value pairs (fields).
 * Boolean - One of two possible values, `true`or `false`. Boolean values must be JSON booleans, not strings (i.e. `true` or `false`, not `"true"` or `"false"`). *(as of v2.0)*
 * Date - Service day in the YYYY-MM-DD format. Example: `2019-09-13` for September 13th, 2019.
+* Time - Service time in the HH:MM:SS format. Example: `21:20:02` or `01:58:00`
 * Email - An email address. Example: `example@example.com`
 * Enum (Enumerable values) - An option from a set of predefined constants in the "Defines" column.
 Example: The `rental_methods` field contains values `CREDITCARD`, `PAYPASS`, etc...


### PR DESCRIPTION
System hours has two fields `Time` but it isn't documented under `Field Types`