### PR TITLE
For Spin, removed Rotterdam and updates links to new GBFS hostname

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -110,22 +110,22 @@ DE,RSVG-Bike,"RSVG, DE",nextbike_rb,https://www.nextbike.de/de/rsvg/,https://gbf
 DE,RVK,"RVK-Gesamt, DE",nextbike_dr,https://www.nextbike.de/de/rvk/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_dr/gbfs.json
 DE,Santander nextbike Mönchengladbach,"Mönchengladbach, DE",nextbike_sn,https://www.nextbike.de/de/moenchengladbach/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_sn/gbfs.json
 DE,SAP Walldorf,"Walldorf, DE",nextbike_ds,https://www.nextbike.de/de/walldorf/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ds/gbfs.json
-DE,Spin Bonn,"Bonn, DE",spin Bonn,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/Bonn/gbfs
-DE,Spin Brühl,"Brühl, DE",spin brühl,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/br%C3%BChl/gbfs
-DE,Spin Cologne,"Cologne, DE",spin cologne,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/cologne/gbfs
-DE,Spin Dortmund,"Dortmund, DE",spin dortmund,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/dortmund/gbfs
-DE,Spin Dulsburg,"Duisburg, DE",spin duisburg,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/duisburg/gbfs
-DE,Spin Essen,"Essen, DE",spin essen,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/essen/gbfs
-DE,Spin Frechen,"Frechen, DE",spin frechen,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/frechen/gbfs
-DE,Spin Gelsenkirchen,"Gelsenkirchen, DE",spin gelsenkirchen,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/gelsenkirchen/gbfs
-DE,Spin Hennef,"Hennef,DE",spin hennef,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/hennef/gbfs
-DE,Spin Herne,"Herne, DE",spin herne,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/herne/gbfs
-DE,Spin Lohmar,"Lohmar, DE",spin lohmar,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/lohmar/gbfs
-DE,Spin Mülheim,"Mülheim DE",spin mulheim,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/mulheim/gbfs
-DE,Spin Recklinghausen,"Recklinghausen, DE",spin recklinghausen,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/recklinghausen/gbfs
-DE,Spin Rheinland,"Rheinland, DE",spin rheinland,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/rheinland/gbfs
-DE,Spin Troisdorf,"Troisdord, DE",spin troisdorf,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/troisdorf/gbfs
-DE,Spin Wesseling,"Wesseling DE",spin wesseling,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/wesseling/gbfs
+DE,Spin Bonn,"Bonn, DE",spin Bonn,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/Bonn/gbfs
+DE,Spin Brühl,"Brühl, DE",spin brühl,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/br%C3%BChl/gbfs
+DE,Spin Cologne,"Cologne, DE",spin cologne,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/cologne/gbfs
+DE,Spin Dortmund,"Dortmund, DE",spin dortmund,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/dortmund/gbfs
+DE,Spin Dulsburg,"Duisburg, DE",spin duisburg,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/duisburg/gbfs
+DE,Spin Essen,"Essen, DE",spin essen,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/essen/gbfs
+DE,Spin Frechen,"Frechen, DE",spin frechen,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/frechen/gbfs
+DE,Spin Gelsenkirchen,"Gelsenkirchen, DE",spin gelsenkirchen,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/gelsenkirchen/gbfs
+DE,Spin Hennef,"Hennef,DE",spin hennef,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/hennef/gbfs
+DE,Spin Herne,"Herne, DE",spin herne,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/herne/gbfs
+DE,Spin Lohmar,"Lohmar, DE",spin lohmar,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/lohmar/gbfs
+DE,Spin Mülheim,"Mülheim DE",spin mulheim,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/mulheim/gbfs
+DE,Spin Recklinghausen,"Recklinghausen, DE",spin recklinghausen,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/recklinghausen/gbfs
+DE,Spin Rheinland,"Rheinland, DE",spin rheinland,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/rheinland/gbfs
+DE,Spin Troisdorf,"Troisdord, DE",spin troisdorf,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/troisdorf/gbfs
+DE,Spin Wesseling,"Wesseling DE",spin wesseling,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/wesseling/gbfs
 DE,Sprottenflotte,"KielRegion, DE",nextbike_sf,https://www.nextbike.de/de/kielregion/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_sf/gbfs.json
 DE,SWA Rad,"Augsburg, DE",nextbike_ag,https://www.swa-rad.de/de/augsburg/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ag/gbfs.json
 DE,UsedomRad Germany,"Usedom, DE",nextbike_ur,https://usedomrad.de/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ur/gbfs.json
@@ -155,7 +155,7 @@ ES,Donkey Republic Barcelona,"Barcelona, ES",donkey_barcelona,https://www.donkey
 ES,ibizi,"Ibiza-City, ES",nextbike_ei,https://www.nextbike.es/es/ibiza/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ei/gbfs.json
 ES,Lovesharing (Canary Islands),"ES",nextbike_ls,https://www.lovesharing.com/bikesharing/es/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ls/gbfs.json
 ES,Sitycleta (Las Palmas),"Las Palmas de Gran Canaria, ES",nextbike_el,https://www.sitycleta.com/es/laspalmas/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_el/gbfs.json
-ES,Spin Madrid,"Mardid, ES",spin madrid,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/Madrid/gbfs
+ES,Spin Madrid,"Mardid, ES",spin madrid,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/Madrid/gbfs
 FI,Donkey Republic Hämeenlinna,Hämeenlinna,donkey_haemeenlinna,https://www.donkey.bike/cities/bike-rental-hameenlinna/,https://stables.donkey.bike/api/public/gbfs/donkey_haemeenlinna/gbfs.json
 FI,Donkey Republic Hamina,Hamina,donkey_hamina,https://www.donkey.bike/cities/bike-rental-hamina/,https://stables.donkey.bike/api/public/gbfs/donkey_hamina/gbfs.json
 FI,Donkey Republic Iisalmi,Iisalmi,donkey_iisalmi,https://www.donkey.bike/cities/bike-rental-iisalmi/,https://stables.donkey.bike/api/public/gbfs/donkey_iisalmi/gbfs.json
@@ -224,11 +224,11 @@ GB,Pony Oxford,"Oxford, GB",pony_oxford,https://getapony.com,https://gbfs.getapo
 GB,Santander Cycles - Brunel,"Brunel University, GB",nextbike_ub,https://www.santandercycles.co.uk/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ub/gbfs.json
 GB,Santander Cycles - Milton Keynes,"Milton Keynes, GB",nextbike_ku,https://www.santandercycles.co.uk/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ku/gbfs.json
 GB,Santander Cycles - Swansea,"Swansea University, GB",nextbike_uu,https://www.santandercycles.co.uk/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_uu/gbfs.json
-GB,Spin Basildon,"Basildon, GB",spin basildon,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/basildon/gbfs
-GB,Spin Chelmsford,"Chelmsford, GB",spin chelmsford,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/chelmsford/gbfs
-GB,Spin Clacton,"Clacton-on-Sea, GB",spin clacton,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/clacton/gbfs
-GB,Spin Colchester,"Colchester, GB",spin colchester,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/colchester/gbfs
-GB,Spin Milton Keynes,"Milton Keynes, GB",spin milton_keynes,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/milton_keynes/gbfs
+GB,Spin Basildon,"Basildon, GB",spin basildon,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/basildon/gbfs
+GB,Spin Chelmsford,"Chelmsford, GB",spin chelmsford,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/chelmsford/gbfs
+GB,Spin Clacton,"Clacton-on-Sea, GB",spin clacton,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/clacton/gbfs
+GB,Spin Colchester,"Colchester, GB",spin colchester,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/colchester/gbfs
+GB,Spin Milton Keynes,"Milton Keynes, GB",spin milton_keynes,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/milton_keynes/gbfs
 GB,University of Surrey,"University of Surrey, GB",nextbike_su,https://www.nextbike.co.uk/en/university-of-surrey/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_su/gbfs.json
 HR,Grad Drniš (Croatia),"Drniš, HR",nextbike_gd,https://www.nextbike.hr/hr/drnis/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_gd/gbfs.json
 HR,Grad Gospić (Croatia),"Gospić, HR",nextbike_gs,https://www.nextbike.hr/hr/gospic/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_gs/gbfs.json
@@ -284,7 +284,6 @@ NL,Donkey Republic Rotterdam,"Rotterdam, NL",donkey_rt,https://www.donkey.bike/n
 NL,Donkey Republic Utrecht,"Utrecht, NL",donkey_ut,https://www.donkey.bike/cities/bike-rental-utrecht/,https://stables.donkey.bike/api/public/gbfs/donkey_ut/gbfs.json
 NL,nextbike Dordrecht,"Dordrecht, NL",nextbike_nd,https://www.nextbike.nl/nl/dordrecht/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_nd/gbfs.json
 NL,NS OV Fiets,"Netherlands",ns_ov_fiets,https://www.ns.nl/en/door-to-door/ov-fiets,http://gbfs.openov.nl/ovfiets/gbfs.json
-NL,Spin Rotterdam,"Rotterdam, NL",spin rotterdam,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/rotterdam/gbfs
 NO,Bergen City Bike,"Bergen, NO",bergen-city-bike,https://bergenbysykkel.no/en,https://gbfs.urbansharing.com/bergenbysykkel.no/gbfs.json
 NO,Oslo City Bike,"Oslo, NO",oslobysykkel,https://oslobysykkel.no/en,https://gbfs.urbansharing.com/oslobysykkel.no/gbfs.json
 NO,Trondheim City Bike,"Trondheim, NO",trondheim,https://trondheimbysykkel.no/en,https://gbfs.urbansharing.com/trondheimbysykkel.no/gbfs.json
@@ -442,87 +441,87 @@ US,San Antonio B-cycle,"San Antonio, TX",bcycle_sanantonio,https://sanantonio.bc
 US,Santa Barbara BCycle,"Santa Barbara, CA",bcycle_santabarbara,https://santabarbara.bcycle.com,https://gbfs.bcycle.com/bcycle_santabarbara/gbfs.json
 US,SBU Wolf Ride Bike Share,"Stony Brook, NY",sbu,https://www.stonybrook.edu/commcms/sustainability/transportation/_Wolf_Ride_Bike_Share/,https://sbu.publicbikesystem.net/ube/gbfs/v1/
 US,Spartanburg BCycle,"Spartanburg, SC",bcycle_spartanburg,https://spartanburg.bcycle.com,https://gbfs.bcycle.com/bcycle_spartanburg/gbfs.json
-US,Spin Aiken,"Aiken, SC",spin aiken,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/aiken/gbfs
-US,Spin Albuquerque,"Albuquerque, NM",spin albuquerque,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/albuquerque/gbfs
-US,Spin Alexandria,"Alexandria, VA",spin alexandria,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/alexandria/gbfs
-US,Spin Ann Arbor,"Ann Arbor, MI",spin ann_arbor,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/ann_arbor/gbfs
-US,Spin Arkadelphia,"Arkadelphia, VA",spin arkadelphia,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/arkadelphia/gbfs
-US,Spin Arlington,"Arlington, VA",spin arlington,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/arlington/gbfs
-US,Spin Asbury Park,"Asbury Park, NY",spin asbury_park,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/asbury_park/gbfs
-US,Spin Atlanta,"Atlanta, GA",spin atlanta,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/atlanta/gbfs
-US,Spin Austin,"Austin, TX",spin austin,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/austin/gbfs
-US,Spin Baltimore,"Baltimore, MD",spin baltimore,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/baltimore/gbfs.json
-US,Spin Boise,"Boise, ID",spin boise,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/boise/gbfs
-US,Spin Brookline,"Brookline, MA",spin brookline,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/brookline/gbfs
-US,Spin Charlotte,"Charlotte,NC",spin charlotte,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/charlotte/gbfs
+US,Spin Aiken,"Aiken, SC",spin aiken,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/aiken/gbfs
+US,Spin Albuquerque,"Albuquerque, NM",spin albuquerque,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/albuquerque/gbfs
+US,Spin Alexandria,"Alexandria, VA",spin alexandria,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/alexandria/gbfs
+US,Spin Ann Arbor,"Ann Arbor, MI",spin ann_arbor,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/ann_arbor/gbfs
+US,Spin Arkadelphia,"Arkadelphia, VA",spin arkadelphia,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/arkadelphia/gbfs
+US,Spin Arlington,"Arlington, VA",spin arlington,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/arlington/gbfs
+US,Spin Asbury Park,"Asbury Park, NY",spin asbury_park,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/asbury_park/gbfs
+US,Spin Atlanta,"Atlanta, GA",spin atlanta,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/atlanta/gbfs
+US,Spin Austin,"Austin, TX",spin austin,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/austin/gbfs
+US,Spin Baltimore,"Baltimore, MD",spin baltimore,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/baltimore/gbfs.json
+US,Spin Boise,"Boise, ID",spin boise,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/boise/gbfs
+US,Spin Brookline,"Brookline, MA",spin brookline,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/brookline/gbfs
+US,Spin Charlotte,"Charlotte,NC",spin charlotte,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/charlotte/gbfs
 US,Spin Chicago,"Chicago, IL",spin chicago,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/chicago_territory/gbfs
-US,Spin Cleveland,"Cleveland, OH",spin cleveland,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/cleveland/gbfs
-US,Spin Columbus,"Columbus, OH",spin columbus,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/columbus/gbfs
-US,Spin Coral Gables,"Coral Gables, FL",spin coral_gables,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/coral_gables/gbfs
-US,Spin Dayton,"Dayton, OH",spin dayton,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/dayton/gbfs
-US,Spin Denver,"Denver, CO",spin denver,https://www.spin.pm, https://web.spin.pm/api/gbfs/v1/denver/gbfs
-US,Spin Detroit,"Detroit, MI",spin detroit,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/detroit/gbfs
-US,Spin Duke,"Durham NS",spin duke,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/duke/gbfs
-US,Spin Durham,"Durham, NC",spin durham,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/durham/gbfs
-US,Spin Edwards Air Force Base,"Edwards, CA",spin edwards_air_force_base,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/edwards_air_force_base/gbfs
-US,Spin Fayetteville,"Fayetteville, AR",spin fayetteville,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/fayetteville/gbfs
-US,Spin Fort Pierce,"Fort Pierce, FL",spin fort_pierce,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/fort_pierce/gbfs
-US,Spin Grand Rapids,"Grand Rapids, MI",spin grand_rapids,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/grand_rapids/gbfs
-US,Spin Greenville,"Greenville, SC",spin greenville,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/greenville/gbfs
-US,Spin Isla Vista,"Isla Vista, CA",spin isla_vista,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/isla_vista/gbfs
-US,Spin Jacksonville,"Jacksonville, FL", spin jacksonville, https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/jacksonville/gbfs
-US,Spin Jefferson City,"Jefferson City, MO",spin jefferson_city,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/jefferson_city/gbfs
-US,Spin Kansas City,"Kansas City, MO",spin kansas_city,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/kansas_city/gbfs
-US,Spin Knoxville,"Knoxville, TN",spin knoxville,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/knoxville/gbfs
-US,Spin Lexington,"Lexington, KY",spin lexington,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/lexington/gbfs
-US,Spin Lincoln,"Lincoln, NB",spin lincoln,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/lincoln/gbfs
-US,Spin Long Beach,"Long Beach, CA",spin long_beach,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/long_beach/gbfs
-US,Spin Los Angeles,"Los Angeles, CA",spin los_angeles,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/los_angeles/gbfs
-US,Spin Louisville,"Louisville, KY",spin louisville,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/louisville/gbfs
-US,Spin Memphis,"Memphis, TN",spin memphis,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/memphis/gbfs
-US,Spin Mesa,"Mesa, AZ",spin mesa,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/mesa/gbfs
-US,Spin Milwaukee,"Milwaukee, WI",spin milwaukee,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/milwaukee/gbfs
-US,Spin Minneapolis,"Minneapolis, MN",spin minneapolis,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/minneapolis/gbfs
-US,Spin Mongomery County,"Mongomery County, MD",spin montgomery_county,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/montgomery_county/gbfs
-US,Spin Nashville,"Nashville, TN",spin nashville,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/nashville/gbfs
-US,Spin Oakland,"Oakland, CA",spin oakland,https://www.spin.pm,https://web.spin.pm/api/gbfs/v2/oakland/gbfs
-US,Spin Oakland University,"Rochester, MI",spin oakland_university,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/oakland_university/gbfs
-US,Spin Ohio State,"Columbus, OH",spin ohio_state,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/ohio_state/gbfs
-US,Spin Omaha,"Omaha, NB",spin omaha,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/omaha/gbfs
-US,Spin Orem,"Orem, UT",spin orem,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/orem/gbfs
-US,Spin Orlando,"Orlando, FL",spin orlando,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/orlando/gbfs
-US,Spin Phoenix,"Phoenix, AZ",spin phoenix,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/phoenix/gbfs
-US,Spin Portland,"Portland, OR",spin portland,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/portland/gbfs
-US,Spin Providence,"Providence, RI",spin providence,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/providence/gbfs
-US,Spin Provo,"Provo, UT",spin provo,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/provo/gbfs
-US,Spin Purdue University,"West Lafayette, IN",spin purdue_university,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/purdue_university/gbfs
-US,Spin Sacramento,"Sacramento, CA",spin sacramento,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/sacramento/gbfs
-US,Spin Salem,"Salem, MA",spin salem,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/salem/gbfs
-US,Spin Salt Lake City,"Salt Lake City, UT",spin salt_lake_city,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/salt_lake_city/gbfs
-US,Spin San Antonio,"San Antonio, TX",spin san_antonio,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/san_antonio/gbfs
-US,Spin San Diego,"San Diego, CA",spin san_diego,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/san_diego/gbfs
-US,Spin San Francisco,"San Francisco, CA",spin san_francisco,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/san_francisco/gbfs
-US,Spin San Jose,"San Jose, CA",spin san_jose,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/san_jose/gbfs
-US,Spin San Marcos,"San Marcos, TX",spin san_marcos,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/san_marcos/gbfs
-US,Spin Scottsdale,"Scottsdale, AZ",spin scottsdale,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/scottsdale/gbfs
-US,Spin South Miami,"South Miami, FL",spin south_miami,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/south_miami/gbfs
-US,Spin St George,"St George, UT",spin st_george,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/st_george/gbfs
-US,Spin Stillwater,"Stillwater, OK",spin stillwater,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/stillwater/gbfs
-US,Spin St Louis,"St Louis, MO",spin st_louis,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/st_louis/gbfs
-US,Spin Tallahassee,"Tallahassee, FL",spin tallahassee,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/tallahassee/gbfs
-US,Spin Tampa,"Tampa, FL",spin tampa,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/tampa/gbfs
-US,Spin Tempe,"Tempe, AZ",spin tempe,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/tempe/gbfs
-US,Spin Towson,"Towson, MD",spin towson,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/towson/gbfs
-US,Spin Troy,"Troy, AL",spin troy,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/troy/gbfs
-US,Spin UC San Diego,"San Diego, CA",spin uc_san_diego,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/uc_san_diego/gbfs
-US,Spin University of Central Florida,"Orlando, FL",spin university_of_central_florida,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/university_of_central_florida/gbfs
-US,Spin University of Kentucky,"Lexington, KY",spin university_of_kentucky,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/university_of_kentucky/gbfs
-US,Spin Virginia Tech,"Blackburg, VA",spin virginia_tech,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/virginia_tech/gbfs
-US,Spin Washington DC,"Washington, DC",spin washington_dc,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/washington_dc/gbfs
-US,Spin West Sacramento,"West Sacramento, CA",spin west_sacramento,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/west_sacramento/gbfs
-US,Spin White Center,"White Center, WA",spin white_center,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/white_center/gbfs
-US,Spin Wichita,"Wichita, KS",spin wichita,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/wichita/gbfs
-US,Spin Winston Salem,"Winston Salem, NC",spin winston_salem,https://www.spin.pm,https://web.spin.pm/api/gbfs/v1/winston_salem/gbfs
+US,Spin Cleveland,"Cleveland, OH",spin cleveland,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/cleveland/gbfs
+US,Spin Columbus,"Columbus, OH",spin columbus,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/columbus/gbfs
+US,Spin Coral Gables,"Coral Gables, FL",spin coral_gables,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/coral_gables/gbfs
+US,Spin Dayton,"Dayton, OH",spin dayton,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/dayton/gbfs
+US,Spin Denver,"Denver, CO",spin denver,https://www.spin.pm, https://gbfs.spin.pm/api/gbfs/v1/denver/gbfs
+US,Spin Detroit,"Detroit, MI",spin detroit,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/detroit/gbfs
+US,Spin Duke,"Durham NS",spin duke,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/duke/gbfs
+US,Spin Durham,"Durham, NC",spin durham,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/durham/gbfs
+US,Spin Edwards Air Force Base,"Edwards, CA",spin edwards_air_force_base,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/edwards_air_force_base/gbfs
+US,Spin Fayetteville,"Fayetteville, AR",spin fayetteville,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/fayetteville/gbfs
+US,Spin Fort Pierce,"Fort Pierce, FL",spin fort_pierce,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/fort_pierce/gbfs
+US,Spin Grand Rapids,"Grand Rapids, MI",spin grand_rapids,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/grand_rapids/gbfs
+US,Spin Greenville,"Greenville, SC",spin greenville,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/greenville/gbfs
+US,Spin Isla Vista,"Isla Vista, CA",spin isla_vista,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/isla_vista/gbfs
+US,Spin Jacksonville,"Jacksonville, FL", spin jacksonville, https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/jacksonville/gbfs
+US,Spin Jefferson City,"Jefferson City, MO",spin jefferson_city,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/jefferson_city/gbfs
+US,Spin Kansas City,"Kansas City, MO",spin kansas_city,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/kansas_city/gbfs
+US,Spin Knoxville,"Knoxville, TN",spin knoxville,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/knoxville/gbfs
+US,Spin Lexington,"Lexington, KY",spin lexington,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/lexington/gbfs
+US,Spin Lincoln,"Lincoln, NB",spin lincoln,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/lincoln/gbfs
+US,Spin Long Beach,"Long Beach, CA",spin long_beach,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/long_beach/gbfs
+US,Spin Los Angeles,"Los Angeles, CA",spin los_angeles,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/los_angeles/gbfs
+US,Spin Louisville,"Louisville, KY",spin louisville,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/louisville/gbfs
+US,Spin Memphis,"Memphis, TN",spin memphis,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/memphis/gbfs
+US,Spin Mesa,"Mesa, AZ",spin mesa,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/mesa/gbfs
+US,Spin Milwaukee,"Milwaukee, WI",spin milwaukee,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/milwaukee/gbfs
+US,Spin Minneapolis,"Minneapolis, MN",spin minneapolis,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/minneapolis/gbfs
+US,Spin Mongomery County,"Mongomery County, MD",spin montgomery_county,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/montgomery_county/gbfs
+US,Spin Nashville,"Nashville, TN",spin nashville,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/nashville/gbfs
+US,Spin Oakland,"Oakland, CA",spin oakland,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v2/oakland/gbfs
+US,Spin Oakland University,"Rochester, MI",spin oakland_university,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/oakland_university/gbfs
+US,Spin Ohio State,"Columbus, OH",spin ohio_state,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/ohio_state/gbfs
+US,Spin Omaha,"Omaha, NB",spin omaha,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/omaha/gbfs
+US,Spin Orem,"Orem, UT",spin orem,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/orem/gbfs
+US,Spin Orlando,"Orlando, FL",spin orlando,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/orlando/gbfs
+US,Spin Phoenix,"Phoenix, AZ",spin phoenix,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/phoenix/gbfs
+US,Spin Portland,"Portland, OR",spin portland,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/portland/gbfs
+US,Spin Providence,"Providence, RI",spin providence,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/providence/gbfs
+US,Spin Provo,"Provo, UT",spin provo,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/provo/gbfs
+US,Spin Purdue University,"West Lafayette, IN",spin purdue_university,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/purdue_university/gbfs
+US,Spin Sacramento,"Sacramento, CA",spin sacramento,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/sacramento/gbfs
+US,Spin Salem,"Salem, MA",spin salem,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/salem/gbfs
+US,Spin Salt Lake City,"Salt Lake City, UT",spin salt_lake_city,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/salt_lake_city/gbfs
+US,Spin San Antonio,"San Antonio, TX",spin san_antonio,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/san_antonio/gbfs
+US,Spin San Diego,"San Diego, CA",spin san_diego,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/san_diego/gbfs
+US,Spin San Francisco,"San Francisco, CA",spin san_francisco,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/san_francisco/gbfs
+US,Spin San Jose,"San Jose, CA",spin san_jose,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/san_jose/gbfs
+US,Spin San Marcos,"San Marcos, TX",spin san_marcos,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/san_marcos/gbfs
+US,Spin Scottsdale,"Scottsdale, AZ",spin scottsdale,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/scottsdale/gbfs
+US,Spin South Miami,"South Miami, FL",spin south_miami,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/south_miami/gbfs
+US,Spin St George,"St George, UT",spin st_george,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/st_george/gbfs
+US,Spin Stillwater,"Stillwater, OK",spin stillwater,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/stillwater/gbfs
+US,Spin St Louis,"St Louis, MO",spin st_louis,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/st_louis/gbfs
+US,Spin Tallahassee,"Tallahassee, FL",spin tallahassee,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/tallahassee/gbfs
+US,Spin Tampa,"Tampa, FL",spin tampa,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/tampa/gbfs
+US,Spin Tempe,"Tempe, AZ",spin tempe,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/tempe/gbfs
+US,Spin Towson,"Towson, MD",spin towson,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/towson/gbfs
+US,Spin Troy,"Troy, AL",spin troy,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/troy/gbfs
+US,Spin UC San Diego,"San Diego, CA",spin uc_san_diego,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/uc_san_diego/gbfs
+US,Spin University of Central Florida,"Orlando, FL",spin university_of_central_florida,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/university_of_central_florida/gbfs
+US,Spin University of Kentucky,"Lexington, KY",spin university_of_kentucky,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/university_of_kentucky/gbfs
+US,Spin Virginia Tech,"Blackburg, VA",spin virginia_tech,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/virginia_tech/gbfs
+US,Spin Washington DC,"Washington, DC",spin washington_dc,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/washington_dc/gbfs
+US,Spin West Sacramento,"West Sacramento, CA",spin west_sacramento,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/west_sacramento/gbfs
+US,Spin White Center,"White Center, WA",spin white_center,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/white_center/gbfs
+US,Spin Wichita,"Wichita, KS",spin wichita,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/wichita/gbfs
+US,Spin Winston Salem,"Winston Salem, NC",spin winston_salem,https://www.spin.pm,https://gbfs.spin.pm/api/gbfs/v1/winston_salem/gbfs
 US,START Bike,"Jackson, WY",bcycle_startbike,https://startbike.bcycle.com,https://gbfs.bcycle.com/bcycle_startbike/gbfs.json
 US,Tugo,"Tucson, AZ",tugo,https://tugobikeshare.com/,https://tuc.publicbikesystem.net/ube/gbfs/v1/
 US,Valentine Bike Share,"Valentine, NE",bcycle_valentine,https://heartlandbikeshare.org,https://gbfs.bcycle.com/bcycle_valentine/gbfs.json


### PR DESCRIPTION
I updated the links from web.spin.pm to gbfs.spin.pm. 
Also, I removed Rotterdam, we are not actively deploying vehicles there

### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure
