### PR TITLE
gbfs.md formatting and consitency changes

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -1,13 +1,17 @@
 
 # General Bikeshare Feed Specification (GBFS)
+
 This document explains the types of files and data that comprise the General Bikeshare Feed Specification (GBFS) and defines the fields used in all of those files.
 
 # Reference version
-This documentation refers to **v3.0-RC (release candidate)**. <br>
+
+This documentation refers to **v3.0-RC (release candidate)**.<br>
 **For the current version see [**version 2.2**](https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md).** For past and upcoming versions see the [README](README.md#read-the-spec--version-history).
 
 ## Terminology
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119](https://tools.ietf.org/html/rfc2119), [BCP 14](https://tools.ietf.org/html/bcp14) and [RFC8174](https://tools.ietf.org/html/rfc8174) when, and only when, they appear in all capitals, as shown here.
+
 ## Table of Contents
 
 * [Introduction](#introduction)
@@ -35,6 +39,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 * [Deep Links - Analytics and Examples](#deep-links-added-in-v11) *(added in v1.1)*
 
 ## Introduction
+
 This specification has been designed with the following concepts in mind:
 
 * Provide the status of the system at this moment
@@ -43,6 +48,7 @@ This specification has been designed with the following concepts in mind:
 The specification supports real-time travel advice in GBFS-consuming applications.
 
 ## Version Endpoints
+
 The version of the GBFS specification to which a feed conforms is declared in the `version` field in all files. See [Output Format](#output-format).<br />
 
 GBFS Best Practice defines that:<br />
@@ -53,8 +59,8 @@ _GBFS consumers_ SHOULD, at a minimum, support the current LTS branch. It is hig
 
 Default GBFS feed URLs, e.g. `https://www.example.com/data/gbfs.json` or `https://www.example.com/data/fr/system_information.json` MUST direct consumers to the feed that conforms to the current LTS documentation branch.
 
-
 ## Term Definitions
+
 This section defines terms that are used throughout this document.
 
 * JSON - (JavaScript Object Notation) is a lightweight format for storing and transporting data. This document uses many terms defined by the JSON standard, including field, array, and object. (https://www.w3schools.com/js/js_json_datatypes.asp)
@@ -80,22 +86,27 @@ system_calendar.json | OPTIONAL | Dates of operation for the system.
 system_regions.json | OPTIONAL | Regions the system is broken up into.
 system_pricing_plans.json | OPTIONAL | System pricing scheme.
 system_alerts.json | OPTIONAL | Current system alerts.
-geofencing_zones.json <br/>*(added in v2.1)* | OPTIONAL | Geofencing zones and their associated rules and attributes.    
+geofencing_zones.json <br/>*(added in v2.1)* | OPTIONAL | Geofencing zones and their associated rules and attributes.
 
-## Accessibility 
-Datasets SHOULD be published at an easily accessible, public, permanent URL. (e.g., www.agency.org/gbfs/v3/gbfs.json). The URL SHOULD be directly available without requiring login to access the file to facilitate download by consuming software applications.  
+## Accessibility
+
+Datasets SHOULD be published at an easily accessible, public, permanent URL. (e.g., https://www.example.com/gbfs/v3/gbfs.json). The URL SHOULD be directly available without requiring login to access the file to facilitate download by consuming software applications.
 
 To be compliant with GBFS, all systems MUST have an entry in the [systems.csv](https://github.com/NABSA/gbfs/blob/master/systems.csv) file.
-### Feed Availability 
-Automated tools for application performance monitoring SHOULD be used to ensure feed availability.  
+
+### Feed Availability
+
+Automated tools for application performance monitoring SHOULD be used to ensure feed availability.
 Producers SHOULD provide a technical contact who can respond to feed outages in the `feed_contact_email` field in the `system_information.json` file.
- 
+
 ### Seasonal Shutdowns, Disruptions of Service
+
 Feeds SHOULD continue to be published during seasonal or temporary shutdowns.  Feed URLs SHOULD NOT return a 404.  An empty bikes array SHOULD be returned by `free_bike_status.json`. Stations in `station_status.json` SHOULD be set to `is_renting:false`, `is_returning:false` and `is_installed:false` where applicable. Seasonal shutdown dates SHOULD be reflected in `system_calendar.json`.
 
 Announcements for disruptions of service, including disabled stations or temporary closures of stations or systems SHOULD be made in `system_alerts.json`.
 
 ## File Requirements
+
 * All files SHOULD be valid JSON
 * All files in the spec MAY be published at a URL path or with an alternate name (e.g., `station_info` instead of `station_information.json`) *(as of v2.0)*.
 * All data SHOULD be UTF-8 encoded
@@ -103,32 +114,36 @@ Announcements for disruptions of service, including disabled stations or tempora
 * Pagination is not supported.
 
 ### File Distribution
+
 * Files are distributed as individual HTTP endpoints.
     * REQUIRED files MUST NOT 404. They MUST return a properly formatted JSON file as defined in [Output Format](#output-format).
     * OPTIONAL files MAY 404. A 404 of an OPTIONAL file SHOULD NOT be considered an error.
-    
-### Auto-Discovery 
-Publishers SHOULD implement auto-discovery of GBFS feeds by linking to the location of the `gbfs.json` auto-discovery endpoint.
- * The location of the auto-discovery file SHOULD be provided in the HTML area of the shared mobility landing page hosted at the URL specified in the URL field of the `system_infomation.json` file.
 
- * This is referenced via a _link_ tag with the following format:
-      * `<link rel="gbfs" type="application/json" href="https://www.example.com/data/gbfs.json" />`
+### Auto-Discovery
+
+Publishers SHOULD implement auto-discovery of GBFS feeds by linking to the location of the `gbfs.json` auto-discovery endpoint.
+
+* The location of the auto-discovery file SHOULD be provided in the HTML area of the shared mobility landing page hosted at the URL specified in the URL field of the `system_infomation.json` file.
+* This is referenced via a _link_ tag with the following format:
+    * `<link rel="gbfs" type="application/json" href="https://www.example.com/data/gbfs.json" />`
     * References:
-      * http://microformats.org/wiki/existing-rel-values
-      * http://microformats.org/wiki/rel-faq#How_is_rel_used
- * A shared mobility landing page MAY contain links to auto-discovery files for multiple systems.
+      * https://microformats.org/wiki/existing-rel-values
+      * https://microformats.org/wiki/rel-faq#How_is_rel_used
+* A shared mobility landing page MAY contain links to auto-discovery files for multiple systems.
+
 ### Localization
+
 * Each set of data files SHOULD be distributed in a single language as defined in system_information.json.
 * A system that wants to publish feeds in multiple languages SHOULD do so by publishing multiple distributions, such as:
     * `https://www.example.com/data/en/system_information.json`
     * `https://www.example.com/data/fr/system_information.json`
-    
+
 ### Text Fields and Naming
 
 Rich text SHOULD NOT be stored in free form text fields. Fields SHOULD NOT contain HTML.
 
 All customer-facing text strings (including station names) SHOULD use Mixed Case (not ALL CAPS), following local conventions for capitalization of place names on displays capable of displaying lower case characters.
-    
+
    * Examples:
      * Central Park South
      * Villiers-sur-Marne
@@ -136,11 +151,12 @@ All customer-facing text strings (including station names) SHOULD use Mixed Case
 
 Abbreviations SHOULD NOT be used for names and other text (e.g. St. for Street) unless a location is called by its abbreviated name (e.g. “JFK Airport”). Abbreviations may be problematic for accessibility by screen reader software and voice user interfaces. Consuming software can be engineered to reliably convert full words to abbreviations for display, but converting from abbreviations to full words is prone to more risk of error.
 
-Names used for stations, virtual stations and geofenced areas SHOULD be human readable. Naming conventions used for locations SHOULD consider a variety of use cases including both text and maps. 
+Names used for stations, virtual stations and geofenced areas SHOULD be human readable. Naming conventions used for locations SHOULD consider a variety of use cases including both text and maps.
 
 Descriptions SHOULD NOT include information so specific that it could be used in tracking of vehicles or trips.
 
 ### Coordinate Precision
+
 Feeds SHOULD provide 6 digits (0.000001) of precision for decimal degrees lat/lon coordinates.
 
 Decimal places | Degrees | Distance at the Equator
@@ -153,10 +169,14 @@ Decimal places | Degrees | Distance at the Equator
 5|0.00001|1.11 m
 **6**|**0.000001**|**0.11 m**
 7|0.0000001|1.11 cm
-### Data Latency 
+
+### Data Latency
+
 The data returned by the near-realtime endpoints `station_status.json` and `free_bike_status.json` SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date.  Appropriate values SHOULD be set using the `ttl` property for each endpoint based on how often the data in feeds are refreshed or updated. For near-realtime endpoints where the data should always be refreshed the `ttl` value SHOULD be `0`. The`last_updated` timestamp represents the publisher's knowledge of the current state of the system at this point in time. The `last_reported` timestamp represents the last time a station or vehicle reported its status to the operator's backend.
-## Licensing 
-It is RECOMMENDED that all GBFS data sets be offered under an open data license. Open data licenses allow consumers to freely use, modify and share GBFS data for any purpose in perpetuity. Licensing of GBFS data provides certainty to GBFS consumers, allowing them to integrate GBFS data into their work. All GBFS data sets SHOULD specify a license using the `license_id` field with an [SPDX identifier](https://spdx.org/licenses/) or by using the `license_url` field with a URL pointing to a custom license in `system_information.json`. See the GBFS repo for a [comparison of a subset of standard licenses](https://github.com/NABSA/gbfs/blob/master/data-licenses.md). 
+
+## Licensing
+
+It is RECOMMENDED that all GBFS data sets be offered under an open data license. Open data licenses allow consumers to freely use, modify and share GBFS data for any purpose in perpetuity. Licensing of GBFS data provides certainty to GBFS consumers, allowing them to integrate GBFS data into their work. All GBFS data sets SHOULD specify a license using the `license_id` field with an [SPDX identifier](https://spdx.org/licenses/) or by using the `license_url` field with a URL pointing to a custom license in `system_information.json`. See the GBFS repo for a [comparison of a subset of standard licenses](https://github.com/NABSA/gbfs/blob/master/data-licenses.md).
 
 ## Field Types
 
@@ -170,11 +190,11 @@ Example: The `rental_methods` field contains values `creditcard`, `paypass`, etc
 * GeoJSON FeatureCollection - A FeatureCollection as described by the IETF RFC 7946 https://tools.ietf.org/html/rfc7946#section-3.3.
 * GeoJSON Multipolygon - A Geometry Object as described by the IETF RFC https://tools.ietf.org/html/rfc7946#section-3.1.7.
 * ID - Should be represented as a string that identifies that particular entity. An ID:
-	* MUST be unique within like fields (e.g. `station_id` MUST be unique among stations)
-	* does not have to be globally unique, unless otherwise specified
-	* MUST NOT contain spaces
-	* MUST be persistent for a given entity (station, plan, etc). An exception is floating bike `bike_id`, which MUST NOT be persistent for privacy reasons (see `free_bike_status.json`). *(as of v2.0)*
-* Language - An IETF BCP 47 language code. For an introduction to IETF BCP 47, refer to http://www.rfc-editor.org/rfc/bcp/bcp47.txt and http://www.w3.org/International/articles/language-tags/. Examples: `en` for English, `en-US` for American English, or `de` for German.
+    * MUST be unique within like fields (e.g. `station_id` MUST be unique among stations)
+    * does not have to be globally unique, unless otherwise specified
+    * MUST NOT contain spaces
+    * MUST be persistent for a given entity (station, plan, etc). An exception is floating bike `bike_id`, which MUST NOT be persistent for privacy reasons (see `free_bike_status.json`). *(as of v2.0)*
+* Language - An IETF BCP 47 language code. For an introduction to IETF BCP 47, refer to https://www.rfc-editor.org/rfc/bcp/bcp47.txt and https://www.w3.org/International/articles/language-tags/. Examples: `en` for English, `en-US` for American English, or `de` for German.
 * Latitude - WGS84 latitude in decimal degrees. The value MUST be greater than or equal to -90.0 and less than or equal to 90.0. Example: `41.890169` for the Colosseum in Rome.
 * Longitude - WGS84 longitude in decimal degrees. The value MUST be greater than or equal to -180.0 and less than or equal to 180.0. Example: `12.492269` for the Colosseum in Rome.
 * Non-negative Float - A 32-bit floating point number greater than or equal to 0.
@@ -183,23 +203,25 @@ Example: The `rental_methods` field contains values `creditcard`, `paypass`, etc
 * String - Can only contain text. Strings MUST NOT contain any formatting codes (including HTML) other than newlines.
 * Time - Service time in the HH:MM:SS format for the time zone indicated in system_information.json (00:00:00 - 47:59:59). Time can stretch up to one additional day in the future to accommodate situations where, for example, a system was open from 11:30pm - 11pm the next day (i.e. 23:30:00-47:00:00).
 * Timestamp - Timestamp fields MUST be represented as integers in POSIX time. (e.g., the number of seconds since January 1st 1970 00:00:00 UTC)
-* Timezone - TZ timezone from the https://www.iana.org/time-zones. Timezone names never contain the space character but MAY contain an underscore. Refer to http://en.wikipedia.org/wiki/List_of_tz_zones for a list of valid values.
+* Timezone - TZ timezone from the https://www.iana.org/time-zones. Timezone names never contain the space character but MAY contain an underscore. Refer to https://en.wikipedia.org/wiki/List_of_tz_zones for a list of valid values.
 Example: `Asia/Tokyo`, `America/Los_Angeles` or `Africa/Cairo`.
-* URI *(added in v1.1)* - A fully qualified URI that includes the scheme (e.g., `com.example.android://`), and any special characters in the URI MUST be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URI values. Note that URIs MAY be URLs.
-* URL - A fully qualified URL that includes `http://` or `https://`, and any special characters in the URL MUST be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
-
+* URI *(added in v1.1)* - A fully qualified URI that includes the scheme (e.g., `com.example.android://`), and any special characters in the URI MUST be correctly escaped. See the following https://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URI values. Note that URIs MAY be URLs.
+* URL - A fully qualified URL that includes `http://` or `https://`, and any special characters in the URL MUST be correctly escaped. See the following https://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
 
 ### Extensions Outside of the Specification
+
 To accommodate the needs of feed producers and consumers prior to the adoption of a change, additional fields can be added to feeds even if these fields are not part of the official specification. Custom extensions that may provide value to the GBFS community and align with the [GBFS Guiding Principles](https://github.com/NABSA/gbfs/blob/master/README.md#guiding-principles) SHOULD be proposed for inclusion in the specification through the change process.
 
- Field names of extensions SHOULD be prefixed with an underscore ( _) character. It is strongly RECOMMENDED that these additional fields be documented on the [wiki](https://github.com/NABSA/gbfs/wiki) page of the GBFS repository in this format:
+Field names of extensions SHOULD be prefixed with an underscore ( _) character. It is strongly RECOMMENDED that these additional fields be documented on the [wiki](https://github.com/NABSA/gbfs/wiki) page of the GBFS repository in this format:
 
 Submitted by | Field Name | File Name | Defines
 ---|---|---|---
 Publisher's name|_field_name|Name of GBFS endpoint where field is used|Description of purpose of use
 
 ## JSON Files
+
 ### Output Format
+
 Every JSON file presented in this specification contains the same common header information at the top level of the JSON response object:
 
 Field Name | REQUIRED | Type | Defines
@@ -209,7 +231,6 @@ Field Name | REQUIRED | Type | Defines
 `version` <br/>*(added in v1.1)* | Yes | String | GBFS version number to which the feed confirms, according to the versioning framework.
 `data` | Yes | Object | Response data in the form of name:value pairs.
 
-
 ##### Example:
 
 ```jsonc
@@ -218,14 +239,17 @@ Field Name | REQUIRED | Type | Defines
   "ttl": 3600,
   "version": "3.0",
   "data": {
-    "name": "Citi Bike",
-    "system_id": "citibike_com"
+    "name": "Example Bike Rental",
+    "system_id": "example_cityname",
+    "timezone": "US/Central",
+    "language": "en"
   }
 }
 ```
 
 ### gbfs.json
-The `gbfs.json` discovery file SHOULD represent a single system or geographic area in which vehicles are operated. The location (URL) of the `gbfs.json` file SHOULD be made available to the public using the specification’s [auto-discovery](#auto-discovery) function. 
+
+The `gbfs.json` discovery file SHOULD represent a single system or geographic area in which vehicles are operated. The location (URL) of the `gbfs.json` file SHOULD be made available to the public using the specification’s [auto-discovery](#auto-discovery) function.
 
 Field Name | REQUIRED | Type | Defines
 ---|---|---|---
@@ -292,12 +316,12 @@ Field Name | REQUIRED | Type | Defines
   "data": {
     "versions": [
       {
-        "version":"2.0",
-        "url":"https://www.example.com/gbfs/2/gbfs"
+        "version": "2.0",
+        "url": "https://www.example.com/gbfs/2/gbfs"
       },
       {
-        "version":"3.0",
-        "url":"https://www.example.com/gbfs/3/gbfs"
+        "version": "3.0",
+        "url": "https://www.example.com/gbfs/3/gbfs"
       }
     ]
   }
@@ -305,6 +329,7 @@ Field Name | REQUIRED | Type | Defines
 ```
 
 ### system_information.json
+
 The following fields are all attributes within the main "data" object for this feed.
 
 Field Name | REQUIRED | Type | Defines
@@ -337,27 +362,27 @@ Field Name | REQUIRED | Type | Defines
 
 ```jsonc
 {
-  "last_updated":1611598155,
-  "ttl":1800,
+  "last_updated": 1611598155,
+  "ttl": 1800,
   "version": "3.0",
-  "data":{
-    "phone_number":"1-800-555-1234",
-    "name":"Example Ride",
-    "operator":"Example Sharing, Inc",
-    "start_date":"2010-06-10",
-    "purchase_url":"https://www.exampleride.org",
-    "timezone":"US/Central",
-    "license_url":"https://exampleride.org/data-license.html",
-    "short_name":"Example Ride",
-    "email":"customerservice@exampleride.org",
-    "url":"http://www.exampleride.org",
-    "feed_contact_email": datafeed@exampleride.org,
-    "system_id":"exampleride",
-    "language":"en",
+  "data": {
+    "phone_number": "1-800-555-1234",
+    "name": "Example Bike Rental",
+    "operator": "Example Sharing, Inc",
+    "start_date": "2010-06-10",
+    "purchase_url": "https://www.example.com",
+    "timezone": "US/Central",
+    "license_url": "https://www.example.com/data-license.html",
+    "short_name": "Example Bike Rental",
+    "email": "customerservice@example.com",
+    "url": "https://www.example.com",
+    "feed_contact_email": "datafeed@example.com",
+    "system_id": "example_cityname",
+    "language": "en",
   }
 }
-
 ```
+
 ### vehicle_types.json *(added in v2.1)*
 
 REQUIRED of systems that include information about vehicle types in the `free_bike_status` file. If this file is not included, then all vehicles in the feed are assumed to be non-motorized bicycles. This file SHOULD be published by systems offering multiple vehicle types for rental, for example pedal bikes and ebikes. <br/>The following fields are all attributes within the main "data" object for this feed.
@@ -406,6 +431,7 @@ Field Name | REQUIRED | Type | Defines
 ```
 
 ### station_information.json
+
 All stations included in `station_information.json` are considered public (e.g., can be shown on a map for public use). If there are private stations (such as Capital Bikeshare’s White House station), these SHOULD NOT be included here. Any station that is represented in `station_information.json` MUST have a corresponding entry in `station_status.json`.
 
 Field Name | REQUIRED | Type | Defines
@@ -421,12 +447,12 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`region_id` | OPTIONAL | ID | Identifier of the region where station is located. See [system_regions.json](#system_regionsjson).
 \-&nbsp;`post_code` | OPTIONAL | String | Postal code where station is located.
 \-&nbsp;`rental_methods` | OPTIONAL | Array | Payment methods accepted at this station. <br /> Current valid values are:<br /> <ul><li>`key` (e.g. operator issued vehicle key / fob / card)</li><li>`creditcard`</li><li>`paypass`</li><li>`applepay`</li><li>`androidpay`</li><li>`transitcard`</li><li>`accountnumber`</li><li>`phone`</li></ul>
-\-&nbsp;`is_virtual_station` <br/>*(added in v2.1)* | OPTIONAL | Boolean | Is this station a location with or without physical infrastructures (docks)? <br /><br /> `true` - The station is a location without physical infrastructure, defined by a point (lat/lon) and/or `station_area` (below). <br /> `false` - The station consists of physical infrastructure (docks). <br /><br /> If this field is empty, it means the station consists of physical infrastructure (docks).<br><br>This field SHOULD be published in systems that have station locations without standard, internet connected physical docking infrastructure. These may be racks or geofenced areas designated for rental and/or return of vehicles. Locations that fit within this description SHOULD have the `is_virtual_station` boolean set to `true`. 
+\-&nbsp;`is_virtual_station` <br/>*(added in v2.1)* | OPTIONAL | Boolean | Is this station a location with or without physical infrastructures (docks)? <br /><br /> `true` - The station is a location without physical infrastructure, defined by a point (lat/lon) and/or `station_area` (below). <br /> `false` - The station consists of physical infrastructure (docks). <br /><br /> If this field is empty, it means the station consists of physical infrastructure (docks).<br><br>This field SHOULD be published in systems that have station locations without standard, internet connected physical docking infrastructure. These may be racks or geofenced areas designated for rental and/or return of vehicles. Locations that fit within this description SHOULD have the `is_virtual_station` boolean set to `true`.
 \-&nbsp;`station_area` <br/>*(added in v2.1)* | OPTIONAL | GeoJSON Multipolygon | A GeoJSON multipolygon that describes the area of a virtual station. If `station_area` is supplied then the record describes a virtual station. <br /><br /> If lat/lon and `station_area` are both defined, the lat/lon is the significant coordinate of the station (e.g. dock facility or valet drop-off and pick up point). The `station_area` takes precedence over any `ride_allowed` rules in overlapping `geofencing_zones`.
 \-&nbsp;`capacity` | OPTIONAL | Non-negative integer | Number of total docking points installed at this station, both available and unavailable, regardless of what vehicle types are allowed at each dock. <br/><br/>If this is a virtual station defined using the `is_virtual_station` field, this number represents the total number of vehicles of all types that can be parked at the virtual station.<br/><br/>If the virtual station is defined by `station_area`, this is the number that can park within the station area. If `lat`/`lon` are defined, this is the number that can park at those coordinates.
 \-&nbsp;`vehicle_capacity` <br/>*(added in v2.1)* | OPTIONAL | Object | An object used to describe the parking capacity of virtual stations (defined using the `is_virtual_station` field), where each key is a `vehicle_type_id` as described in [vehicle_types.json](#vehicle_typesjson-added-in-v21) and the value is a number representing the total number of vehicles of this type that can park within the virtual station.<br/><br/>If the virtual station is defined by `station_area`, this is the number that can park within the station area. If `lat`/`lon` is defined, this is the number that can park at those coordinates.
 \-&nbsp;`vehicle_type_capacity` <br/>*(added in v2.1)* | OPTIONAL | Object | An object used to describe the docking capacity of a station where each key is a `vehicle_type_id` as described in [vehicle_types.json](#vehicle_typesjson-added-in-v21) and the value is a number representing the total docking points installed at this station, both available and unavailable for the specified vehicle type.
-\-&nbsp;`is_valet_station` <br/>*(added in v2.1)* | OPTIONAL | Boolean | Are valet services provided at this station? <br /><br /> `true` - Valet services are provided at this station. <br /> `false` - Valet services are not provided at this station. <br /><br /> If this field is empty, it is assumed that valet services are not provided at this station. <br><br>This field’s boolean SHOULD be set to `true` during the hours which valet service is provided at the station. Valet service is defined as providing unlimited capacity at a station. 
+\-&nbsp;`is_valet_station` <br/>*(added in v2.1)* | OPTIONAL | Boolean | Are valet services provided at this station? <br /><br /> `true` - Valet services are provided at this station. <br /> `false` - Valet services are not provided at this station. <br /><br /> If this field is empty, it is assumed that valet services are not provided at this station. <br><br>This field’s boolean SHOULD be set to `true` during the hours which valet service is provided at the station. Valet service is defined as providing unlimited capacity at a station.
 \-&nbsp;`rental_uris` <br/>*(added in v1.1)* | OPTIONAL | Object | Contains rental URIs for Android, iOS, and web in the android, ios, and web fields. See [examples](#examples-added-in-v11) of how to use these fields and [supported analytics](#analytics-added-in-v11).
 &emsp;\-&nbsp;`android` <br/>*(added in v1.1)* | OPTIONAL | URI | URI that can be passed to an Android app with an `android.intent.action.VIEW` Android intent to support Android Deep Links (https://developer.android.com/training/app-links/deep-linking). Please use Android App Links (https://developer.android.com/training/app-links) if possible so viewing apps don’t need to manually manage the redirect of the user to the app store if the user doesn’t have the application installed. <br><br>This URI SHOULD be a deep link specific to this station, and SHOULD NOT be a general rental page that includes information for more than one station. The deep link SHOULD take users directly to this station, without any prompts, interstitial pages, or logins. Make sure that users can see this station even if they never previously opened the application.  <br><br>If this field is empty, it means deep linking isn’t supported in the native Android rental app. <br><br>Note that URIs do not necessarily include the station_id for this station - other identifiers can be used by the rental app within the URI to uniquely identify this station. <br><br>See the [Analytics](#analytics-added-in-v11) section for how viewing apps can report the origin of the deep link to rental apps. <br><br>Android App Links example value: `https://www.example.com/app?sid=1234567890&platform=android` <br><br>Deep Link (without App Links) example value: `com.example.android://open.example.app/app?sid=1234567890`
 &emsp;\-&nbsp;`ios` <br/>*(added in v1.1)* | OPTIONAL | URI | URI that can be used on iOS to launch the rental app for this station. More information on this iOS feature can be found [here](https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/communicating_with_other_apps_using_custom_urls?language=objc). Please use iOS Universal Links (https://developer.apple.com/ios/universal-links/) if possible so viewing apps don’t need to manually manage the redirect of the user to the app store if the user doesn’t have the application installed. <br><br>This URI SHOULD be a deep link specific to this station, and SHOULD NOT be a general rental page that includes information for more than one station.  The deep link SHOULD take users directly to this station, without any prompts, interstitial pages, or logins. Make sure that users can see this station even if they never previously opened the application.  <br><br>If this field is empty, it means deep linking isn’t supported in the native iOS rental app. <br><br>Note that the URI does not necessarily include the station_id - other identifiers can be used by the rental app within the URL to uniquely identify this station. <br><br>See the [Analytics](#analytics-added-in-v11) section for how viewing apps can report the origin of the deep link to rental apps. <br><br>iOS Universal Links example value: `https://www.example.com/app?sid=1234567890&platform=ios` <br><br>Deep Link (without Universal Links) example value: `com.example.ios://open.example.app/app?sid=1234567890`
@@ -460,19 +486,21 @@ Field Name | REQUIRED | Type | Defines
 
 ```jsonc
 {
-  "last_updated":1609866247,
-  "ttl":0,
-  "version":"3.0",
-  "data":{
-    "stations":[
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "3.0",
+  "data": {
+    "stations": [
       {
-        "station_id":"station12",
-        "station_name":"SE Belmont & SE 10 th ",
-        "is_valet_station":false,
-        "is_virtual_station":true,
-        "station_area":{
-          "type":"MultiPolygon",
-          "coordinates":[
+        "station_id": "station12",
+        "name": "SE Belmont & SE 10 th ",
+        "lat": 12.345678,
+        "lon": 45.678901,
+        "is_valet_station": false,
+        "is_virtual_station": true,
+        "station_area": {
+          "type": "MultiPolygon",
+          "coordinates": [
             [
               [
                 [
@@ -499,19 +527,20 @@ Field Name | REQUIRED | Type | Defines
             ]
           ]
         },
-        "capacity":16,
-        "vehicle_capacity":{
-          "abc123":8,
-          "def456":8,
-          "ghi789":16
+        "capacity": 16,
+        "vehicle_capacity": {
+          "abc123": 8,
+          "def456": 8,
+          "ghi789": 16
         }
       }
     ]
   }
 }
-       
 ```
+
 ### station_status.json
+
 Describes the capacity and rental availability of a station. Data returned SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date.  See [Data Latency](#data-latentcy). Data reflects the operator's most recent knowledge of the station’s status. Any station that is represented in `station_status.json` MUST have a corresponding entry in `station_information.json`.
 
 Field Name | REQUIRED | Type | Defines
@@ -523,7 +552,7 @@ Field Name | REQUIRED | Type | Defines
 &emsp;\- `vehicle_type_id` <br/>*(added in v2.1)* | Yes | ID | The `vehicle_type_id` of each vehicle type at the station as described in [vehicle_types.json](#vehicle_typesjson). This field is REQUIRED if the [vehicle_types.json](#vehicle_typesjson) is defined.
 &emsp;\- `count` <br/>*(added in v2.1)* | Yes | Non-negative integer | A number representing the total number of available vehicles of the corresponding `vehicle_type_id` as defined in [vehicle_types.json](#vehicle_typesjson) at the station.
 \-&nbsp;`num_bikes_disabled` | OPTIONAL | Non-negative integer | Number of disabled vehicles of any type at the station. Vendors who do not want to publicize the number of disabled vehicles or docks in their system can opt to omit station `capacity` (in [station_information.json](#station_informationjson), `num_bikes_disabled`, and `num_docks_disabled` *(as of v2.0)*. If station `capacity` is published, then broken docks/vehicles can be inferred (though not specifically whether the decreased capacity is a broken vehicle or dock).
-\-&nbsp;`num_docks_available` | Conditionally REQUIRED <br/>*(as of v2.0)* | Non-negative integer | REQUIRED except for stations that have unlimited docking capacity (e.g. virtual stations) *(as of v2.0)*. Number of functional docks physically at the station that are able to accept vehicles for return. To know if the docks are accepting vehicle returns, see `is_returning`. <br /><br/> If `is_returning` = `true` this is the number of docks that are currently available to accept vehicle returns. If `is_returning` = `false` this is the number of docks that would be available if the station were set to allow returns. 
+\-&nbsp;`num_docks_available` | Conditionally REQUIRED <br/>*(as of v2.0)* | Non-negative integer | REQUIRED except for stations that have unlimited docking capacity (e.g. virtual stations) *(as of v2.0)*. Number of functional docks physically at the station that are able to accept vehicles for return. To know if the docks are accepting vehicle returns, see `is_returning`. <br /><br/> If `is_returning` = `true` this is the number of docks that are currently available to accept vehicle returns. If `is_returning` = `false` this is the number of docks that would be available if the station were set to allow returns.
 \- `vehicle_docks_available` <br/>*(added in v2.1)* | Conditionally REQUIRED | Array | This field is REQUIRED in feeds where the [vehicle_types.json](#vehicle_typesjson) is defined and where certain docks are only able to accept certain vehicle types. If every dock at the station is able to accept any vehicle type, then this field is not REQUIRED. This field's value is an array of objects. Each of these objects is used to model the number of docks available for certain vehicle types. The total number of docks from each of these objects SHOULD add up to match the value specified in the `num_docks_available` field.
 &emsp;\- `vehicle_type_ids` <br/>*(added in v2.1)* | Yes | Array | An array of strings where each string represents a `vehicle_type_id` that is able to use a particular type of dock at the station
 &emsp;\- `count` <br/>*(added in v2.1)* | Yes | Non-negative integer | A number representing the total number of available vehicles of the corresponding vehicle type as defined in the `vehicle_types` array at the station that can accept vehicles of the specified types in the `vehicle_types` array.
@@ -531,8 +560,7 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`is_installed` | Yes | Boolean | Is the station currently on the street?<br/><br/>`true` - Station is installed on the street.<br/>`false` - Station is not installed on the street.<br/><br/>Boolean SHOULD be set to `true` when equipment is present on the street. In seasonal systems where equipment is removed during winter, boolean SHOULD be set to `false` during the off season. May also be set to false to indicate planned (future) stations which have not yet been installed.
 \-&nbsp;`is_renting` | Yes | Boolean | Is the station currently renting vehicles? <br /><br />`true` - Station is renting vehicles. Even if the station is empty, if it would otherwise allow rentals, this value MUST be `true`.<br/>`false` - Station is not renting vehicles.<br/><br/>If the station is temporarily taken out of service and not allowing rentals, this field MUST be set to `false`.<br/><br/>If a station becomes inaccessible to users due to road construction or other factors this field SHOULD be set to `false`. Field SHOULD be set to `false` during hours or days when the system is not offering vehicles for rent.
 \-&nbsp;`is_returning` | Yes | Boolean | Is the station accepting vehicle returns? <br /><br />`true` - Station is accepting vehicle returns. Even if the station is full, if it would otherwise allow vehicle returns, this value MUST be `true`.<br /> `false` - Station is not accepting vehicle returns.<br/><br/>If the station is temporarily taken out of service and not allowing vehicle returns, this field MUST be set to `false`.<br/><br/>If a station becomes inaccessible to users due to road construction or other factors, this field SHOULD be set to `false`.
-\-&nbsp;`last_reported` | Yes | Timestamp | The last time this station reported its status to the operator's backend. 
-
+\-&nbsp;`last_reported` | Yes | Timestamp | The last time this station reported its status to the operator's backend.
 
 ##### Example:
 
@@ -550,43 +578,56 @@ Field Name | REQUIRED | Type | Defines
         "is_returning": true,
         "last_reported": 1609866125,
         "num_docks_available": 3,
-        "vehicle_docks_available": [{
-          "vehicle_type_ids": ["abc123"],
-          "count": 2
-        }, {
-          "vehicle_type_ids": ["def456"],
-          "count": 1
-        }],
+        "vehicle_docks_available": [
+          {
+            "vehicle_type_ids": [ "abc123" ],
+            "count": 2
+          },
+          {
+            "vehicle_type_ids": [ "def456" ],
+            "count": 1
+          }
+        ],
         "num_bikes_available": 1,
-        "vehicle_types_available": [{
-          "vehicle_type_id": "abc123",
-          "count": 1
-        }, {
-          "vehicle_type_id": "def456",
-          "count": 0
-        }]        
-      }, {
+        "vehicle_types_available": [
+          {
+            "vehicle_type_id": "abc123",
+            "count": 1
+          },
+          {
+            "vehicle_type_id": "def456",
+            "count": 0
+          }
+        ]
+      },
+      {
         "station_id": "station 2",
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,
         "last_reported": 1609866106,
         "num_docks_available": 8,
-        "vehicle_docks_available": [{
-          "vehicle_type_ids": ["abc123"],
-          "count": 6
-        }, {
-          "vehicle_type_ids": ["def456"],
-          "count": 2
-        }],
+        "vehicle_docks_available": [
+          {
+            "vehicle_type_ids": [ "abc123" ],
+            "count": 6
+          },
+          {
+            "vehicle_type_ids": [ "def456" ],
+            "count": 2
+          }
+        ],
         "num_bikes_available": 6,
-        "vehicle_types_available": [{
-          "vehicle_type_id": "abc123",
-          "count": 2
-        }, {
-          "vehicle_type_id": "def456",
-          "count": 4
-        }]
+        "vehicle_types_available": [
+          {
+            "vehicle_type_id": "abc123",
+            "count": 2
+          },
+          {
+            "vehicle_type_id": "def456",
+            "count": 4
+          }
+        ]
       }
     ]
   }
@@ -614,35 +655,35 @@ Field Name | REQUIRED | Type | Defines
 \- `last_reported` <br/>*(added in v2.1)* | OPTIONAL | Timestamp | The last time this vehicle reported its status to the operator's backend.
 \- `current_range_meters` <br/>*(added in v2.1)* | Conditionally REQUIRED | Non-negative float | If the corresponding `vehicle_type` definition for this vehicle has a motor, then this field is REQUIRED. This value represents the furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel.
 \- `station_id` <br/>*(added in v2.1)* | Conditionally REQUIRED | ID | Identifier referencing the `station_id` field in [system_information.json](#system_informationjson). REQUIRED only if the vehicle is currently at a station and the [vehicle_types.json](#vehicle_typesjson) file has been defined.
-\- `pricing_plan_id` <br/>*(added in v2.1)* | OPTIONAL | ID | The `plan_id` of the pricing plan this vehicle is eligible for as described in [system_pricing_plans.json](#system_pricing_plans.json). 
+\- `pricing_plan_id` <br/>*(added in v2.1)* | OPTIONAL | ID | The `plan_id` of the pricing plan this vehicle is eligible for as described in [system_pricing_plans.json](#system_pricing_plans.json).
 
 ##### Example:
 
 ```jsonc
 {
-  "last_updated":1609866247,
-  "ttl":0,
-  "version":"3.0",
-  "data":{
-    "bikes":[
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "3.0",
+  "data": {
+    "bikes": [
       {
-        "bike_id":"ghi789",
-        "last_reported":1609866109,
-        "lat":12.34,
-        "lon":56.78,
-        "is_reserved":false,
-        "is_disabled":false,
-        "vehicle_type_id":"abc123"
+        "bike_id": "ghi789",
+        "last_reported": 1609866109,
+        "lat": 12.345678,
+        "lon": 56.789012,
+        "is_reserved": false,
+        "is_disabled": false,
+        "vehicle_type_id": "abc123"
       },
       {
-        "bike_id":"jkl012",
-        "last_reported":1609866204,
-        "is_reserved":false,
-        "is_disabled":false,
-        "vehicle_type_id":"def456",
-        "current_range_meters":6543,
-        "station_id":86,
-        "pricing_plan_id":"plan3"
+        "bike_id": "jkl012",
+        "last_reported": 1609866204,
+        "is_reserved": false,
+        "is_disabled": false,
+        "vehicle_type_id": "def456",
+        "current_range_meters": 6543,
+        "station_id": "86",
+        "pricing_plan_id": "plan3"
       }
     ]
   }
@@ -651,6 +692,7 @@ Field Name | REQUIRED | Type | Defines
 ```
 
 ### system_hours.json
+
 This OPTIONAL file is used to describe hours and days of operation when vehicles are available for rental. If `system_hours.json` is not published, it indicates that vehicles are available for rental 24 hours a day, 7 days a week.
 
 Field Name | REQUIRED | Type | Defines
@@ -662,6 +704,7 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`end_time` | Yes | Time | End time for the hours of operation of the system in the time zone indicated in [system_information.json](#system_informationjson).
 
 ##### Example:
+
 ```jsonc
 {
   "last_updated": 1609866247,
@@ -671,19 +714,34 @@ Field Name | REQUIRED | Type | Defines
     "rental_hours": [
       {
         "user_types": [ "member" ],
-        "days": ["sat", "sun"],
+        "days": [
+          "sat",
+          "sun"
+        ],
         "start_time": "00:00:00",
         "end_time": "23:59:59"
       },
       {
         "user_types": [ "nonmember" ],
-        "days": ["sat", "sun"],
+        "days": [
+          "sat",
+          "sun"
+        ],
         "start_time": "05:00:00",
         "end_time": "23:59:59"
       },
       {
-        "user_types": [ "member", "nonmember" ],
-        "days": ["mon", "tue", "wed", "thu", "fri"],
+        "user_types": [
+          "member",
+          "nonmember"
+        ],
+        "days": [
+          "mon",
+          "tue",
+          "wed",
+          "thu",
+          "fri"
+        ],
         "start_time": "00:00:00",
         "end_time": "23:59:59"
       }
@@ -693,6 +751,7 @@ Field Name | REQUIRED | Type | Defines
 ```
 
 ### system_calendar.json
+
 Describes the operating calendar for a system. This OPTIONAL file SHOULD be published by systems that operate seasonally or do not offer continuous year-round service.
 
 Field Name | REQUIRED | Type | Defines
@@ -706,27 +765,29 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`end_year` | OPTIONAL | Non-negative Integer | Ending year for the system operations.
 
 ##### Example:
+
 ```jsonc
 {
-  "last_updated":1604333830,
-  "ttl":86400,
+  "last_updated": 1604333830,
+  "ttl": 86400,
   "version": "3.0",
-  "data":{
-    "calendars":[
+  "data": {
+    "calendars": [
       {
-        "start_month":4,
-        "start_day":1,
-        "start_year":2020,
-        "end_month":11,
-        "end_day":5,
-        "end_year":2020
+        "start_month": 4,
+        "start_day": 1,
+        "start_year": 2020,
+        "end_month": 11,
+        "end_day": 5,
+        "end_year": 2020
       }
     ]
   }
 }
-
 ```
+
 ### system_regions.json
+
 Describe regions for a system that is broken up by geographic or political region.
 
 Field Name | REQUIRED | Type | Defines
@@ -736,34 +797,37 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`name` | Yes | String | Public name for this region.
 
 ##### Example:
+
 ```jsonc
 {
-  "last_updated":1604332380,
-  "ttl":86400,
+  "last_updated": 1604332380,
+  "ttl": 86400,
   "version": "3.0",
-  "data":{
-    "regions":[
+  "data": {
+    "regions": [
       {
-        "name":"North",
-        "region_id":"3"
+        "name": "North",
+        "region_id": "3"
       },
       {
-        "name":"East",
-        "region_id":"4"
+        "name": "East",
+        "region_id": "4"
       },
       {
-        "name":"South",
-        "region_id":"5"
+        "name": "South",
+        "region_id": "5"
       },
       {
-        "name":"West",
-        "region_id":"6"
+        "name": "West",
+        "region_id": "6"
       }
     ]
   }
 }
 ```
+
 ### system_pricing_plans.json
+
 Describes pricing for the system.
 
 Field Name | REQUIRED | Type | Defines
@@ -785,14 +849,14 @@ Field Name | REQUIRED | Type | Defines
 &emsp;&emsp;\-&nbsp;`start` <br/>*(added in v2.2)* | Yes | Non-Negative Integer | The minute at which this segment rate starts being charged *(inclusive)*.
 &emsp;&emsp;\-&nbsp;`rate` <br/>*(added in v2.2)* | Yes | Float | Rate that is charged for each minute `interval` after the `start`. Can be a negative number, which indicates that the traveller will receive a discount.
 &emsp;&emsp;\-&nbsp;`interval` <br/>*(added in v2.2)* | Yes | Non-Negative Integer | Interval in minutes at which the `rate` of this segment is either reapplied indefinitely, or if defined, up until (but not including) `end` minute.<br /><br />An interval of 0 indicates the rate is only charged once.
-&emsp;&emsp;\-&nbsp; `end` <br/>*(added in v2.2)* | OPTIONAL | Non-Negative Integer | The minute at which the rate will no longer apply  *(exclusive)* e.g. if `end` is `20` the rate no longer applies after 19:59.<br /><br />If this field is empty, the price issued for this segment is charged until the trip ends, in addition to following segments. 
-\-&nbsp;`surge_pricing` <br/>*(added in v2.2)* | OPTIONAL | Boolean | Is there currently an increase in price in response to increased demand in this pricing plan? If this field is empty, it means these is no surge pricing in effect.<br /><br />`true` - Surge pricing is in effect.<br />  `false` - Surge pricing is not in effect. 
+&emsp;&emsp;\-&nbsp; `end` <br/>*(added in v2.2)* | OPTIONAL | Non-Negative Integer | The minute at which the rate will no longer apply  *(exclusive)* e.g. if `end` is `20` the rate no longer applies after 19:59.<br /><br />If this field is empty, the price issued for this segment is charged until the trip ends, in addition to following segments.
+\-&nbsp;`surge_pricing` <br/>*(added in v2.2)* | OPTIONAL | Boolean | Is there currently an increase in price in response to increased demand in this pricing plan? If this field is empty, it means these is no surge pricing in effect.<br /><br />`true` - Surge pricing is in effect.<br />  `false` - Surge pricing is not in effect.
 
 ### Examples *(added in v2.2)*
 
-##### Example 1: 
+##### Example 1:
 
-The user does not pay more than the base price for the first 10 km. After 10 km the user pays $1 per km. After 25 km the user pays $0.50 per km and an additional $3 every 5 km, the extension price, in addition to $0.50 per km. 
+The user does not pay more than the base price for the first 10 km. After 10 km the user pays $1 per km. After 25 km the user pays $0.50 per km and an additional $3 every 5 km, the extension price, in addition to $0.50 per km.
 
 ```jsonc
 {
@@ -831,9 +895,11 @@ The user does not pay more than the base price for the first 10 km. After 10 km 
   }
 }
 ```
+
 ##### Example 2:
 
-This example demonstrates a pricing scheme that has a rate both by minute and by km. The user is charged $0.25 per km as well as $0.50 per minute. Both of these rates happen concurrently and are not dependent on one another. 
+This example demonstrates a pricing scheme that has a rate both by minute and by km. The user is charged $0.25 per km as well as $0.50 per minute. Both of these rates happen concurrently and are not dependent on one another.
+
 ```jsonc
 {
   "last_updated": 1609866247,
@@ -867,7 +933,9 @@ This example demonstrates a pricing scheme that has a rate both by minute and by
   }
 }
 ```
+
 ### system_alerts.json
+
 This feed is intended to inform customers about changes to the system that do not fall within the normal system operations. For example, system closures due to weather would be listed here, but a system that only operated for part of the year would have that schedule listed in the system_calendar.json feed.<br />
 Obsolete alerts SHOULD be removed so the client application can safely present to the end user everything present in the feed.
 
@@ -887,40 +955,43 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`last_updated` | OPTIONAL | Timestamp | Indicates the last time the info for the alert was updated.
 
 ##### Example:
+
 ```jsonc
 {
-  "last_updated":1604198100,
-  "ttl":60,
+  "last_updated": 1604198100,
+  "ttl": 60,
   "version": "3.0",
-  "data":{
-    "alerts":[
+  "data": {
+    "alerts": [
       {
-        "alert_id":"21",
-        "type":"station_closure",
-        "station_ids":[
+        "alert_id": "21",
+        "type": "station_closure",
+        "station_ids": [
           "123",
           "456",
           "789"
         ],
-        "times":[
+        "times": [
           {
-            "start":"1604448000",
-            "end":"1604674800"
+            "start": "1604448000",
+            "end": "1604674800"
           }
         ],
-        "url":"https://example.com/more-info",
-        "summary":"Disruption of Service",
-        "description":"The three stations on Broadway will be out of service
+        "url": "https://example.com/more-info",
+        "summary": "Disruption of Service",
+        "description": "The three stations on Broadway will be out of service
          from 12:00am Nov 3 to 3:00pm Nov 6th to accommodate road work",
-        "last_updated":1604519393
+        "last_updated": 1604519393
       }
     ]
   }
 }
 ```
+
 ### geofencing_zones.json *(added in v2.1)*
+
 Describes geofencing zones and their associated rules and attributes.<br />
-Geofenced areas are delineated using GeoJSON in accordance with [RFC 7946](https://tools.ietf.org/html/rfc7946). By default, no restrictions apply everywhere. Geofencing zones SHOULD be modeled according to restrictions rather than allowance. An operational area (outside of which vehicles cannot be used) SHOULD be defined with a counterclockwise polygon, and a limitation area (in which vehicles can be used under certain restrictions) SHOULD be defined with a clockwise polygon.<br><br>Geofences and GPS operate in two dimensions. Restrictions placed on an overpass or bridge will also  be applied to the roadway or path beneath.<br><br>Care SHOULD be taken when developing geofence based policies that rely on location data.  Location data from GPS, cellular and Wi-Fi signals are subject to interference resulting in accuracy levels in the tens of meters or greater.  This may result in vehicles being placed within a geofenced zone when they are actually outside or adjacent to the zone. Transit time between server and client can also impact when a user is notified of a geofence based policy. A vehicle traveling at 15kph can be well inside of a restricted zone before a notification is received. 
+Geofenced areas are delineated using GeoJSON in accordance with [RFC 7946](https://tools.ietf.org/html/rfc7946). By default, no restrictions apply everywhere. Geofencing zones SHOULD be modeled according to restrictions rather than allowance. An operational area (outside of which vehicles cannot be used) SHOULD be defined with a counterclockwise polygon, and a limitation area (in which vehicles can be used under certain restrictions) SHOULD be defined with a clockwise polygon.<br><br>Geofences and GPS operate in two dimensions. Restrictions placed on an overpass or bridge will also  be applied to the roadway or path beneath.<br><br>Care SHOULD be taken when developing geofence based policies that rely on location data.  Location data from GPS, cellular and Wi-Fi signals are subject to interference resulting in accuracy levels in the tens of meters or greater.  This may result in vehicles being placed within a geofenced zone when they are actually outside or adjacent to the zone. Transit time between server and client can also impact when a user is notified of a geofence based policy. A vehicle traveling at 15kph can be well inside of a restricted zone before a notification is received.
 
 Field Name | REQUIRED | Type | Defines
 ---|---|---|---
@@ -939,22 +1010,22 @@ Field Name | REQUIRED | Type | Defines
 &emsp;&emsp;&emsp;\-&nbsp;`ride_through_allowed` | Conditionally REQUIRED | Boolean | REQUIRED if `rules` array is defined. Is the ride allowed to travel through this zone? <br /><br /> `true` - Ride can travel through this zone. <br /> `false` - Ride cannot travel through this zone.
 &emsp;&emsp;&emsp;\-&nbsp;`maximum_speed_kph` | OPTIONAL | Non-negative Integer | What is the maximum speed allowed, in kilometers per hour? <br /><br /> If there is no maximum speed to observe, this can be omitted.
 
-
 ##### Example:
+
 ```jsonc
 {
-  "last_updated":1604198100,
-  "ttl":60,
+  "last_updated": 1604198100,
+  "ttl": 60,
   "version": "3.0",
-  "data":{
-    "geofencing_zones":{
-      "type":"FeatureCollection",
-      "features":[
+  "data": {
+    "geofencing_zones": {
+      "type": "FeatureCollection",
+      "features": [
         {
-          "type":"Feature",
-          "geometry":{
-            "type":"MultiPolygon",
-            "coordinates":[
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
               [
                 [
                   [
@@ -1005,19 +1076,19 @@ Field Name | REQUIRED | Type | Defines
               ]
             ]
           },
-          "properties":{
-            "name":"NE 24th/NE Knott",
-            "start":1593878400,
-            "end":1593907260,
-            "rules":[
+          "properties": {
+            "name": "NE 24th/NE Knott",
+            "start": 1593878400,
+            "end": 1593907260,
+            "rules": [
               {
-                "vehicle_type_id":[
+                "vehicle_type_id": [
                   "moped1",
                   "car1"
                 ],
-                "ride_allowed":false,
-                "ride_through_allowed":true,
-                "maximum_speed_kph":10
+                "ride_allowed": false,
+                "ride_through_allowed": true,
+                "maximum_speed_kph": 10
               }
             ]
           }
@@ -1027,6 +1098,7 @@ Field Name | REQUIRED | Type | Defines
   }
 }
 ```
+
 ## Deep Links *(added in v1.1)*
 
 Deep links to iOS, Android, and web apps are supported via URIs in the `system_information.json`, `station_information.json`, and `free_bike_status.json` files. The following sections describe how analytics can be added to these URIs, as well as some examples. For further examples, see ["What's New in GBFS"](https://medium.com/@mobilitydata/whats-new-in-gbfs-v2-0-63eb46e6bdc4).
@@ -1058,48 +1130,51 @@ Other supported parameters include:
 
 ```jsonc
 {
-  "last_updated":1572447999,
-  "ttl":60,
-  "version":"3.0",
-  "data":{
-    "system_id":"example_cityname",
-    "short_name":"Example Bike Rental",
-    "rental_apps":{
-      "android":{
-        "discovery_uri":"com.example.android://"
+  "last_updated": 1572447999,
+  "ttl": 60,
+  "version": "3.0",
+  "data": {
+    "name": "Example Bike Rental",
+    "system_id": "example_cityname",
+    "timezone": "US/Central",
+    "language": "en",
+    "rental_apps": {
+      "android": {
+        "discovery_uri": "com.example.android://"
       },
-      "ios":{
-        "discovery_uri":"com.example.ios://"
+      "ios": {
+        "discovery_uri": "com.example.ios://"
       }
     }
-  ...
+  }
+}
 ```
 
 ##### *station_information.json*
 
 ```jsonc
 {
-  "last_updated":1609866247,
-  "ttl":60,
-  "version":"3.0",
-  "data":{
-    "stations":[
+  "last_updated": 1609866247,
+  "ttl": 60,
+  "version": "3.0",
+  "data": {
+    "stations": [
       {
-        "station_id":"425",
-        "name":"Coppertail",
-        "lat":27.9563335328521,
-        "lon":-82.430436084371,
-        "rental_uris":{
-          "android":"https://www.example.com/app?sid=1234567890&platform=android",
-          "ios":"https://www.example.com/app?sid=1234567890&platform=ios"
+        "station_id": "425",
+        "name": "Coppertail",
+        "lat": 27.956333,
+        "lon": -82.430436,
+        "rental_uris": {
+          "android": "https://www.example.com/app?sid=1234567890&platform=android",
+          "ios": "https://www.example.com/app?sid=1234567890&platform=ios"
         }
-      },
-  ...
+      }
+    ]
+  }
+}
 ```
 
-
 Note that the Android URI and iOS Universal Link URLs don’t necessarily use the same identifier as the station_id.
-
 
 ##### Example 2 - App Links are not supported on Android and Universal Links are not supported on iOS, but deep links are still supported on Android and iOS:
 
@@ -1108,11 +1183,13 @@ Note that the Android URI and iOS Universal Link URLs don’t necessarily use th
 ```jsonc
 {
   "last_updated": 1572447999,
-  "ttl":60,
+  "ttl": 60,
   "version": "3.0",
   "data": {
+    "name": "Example Bike Rental",
     "system_id": "example_cityname",
-    "short_name": "Example Bike Rental",
+    "timezone": "US/Central",
+    "language": "en",
     "rental_apps": {
       "android": {
         "discovery_uri": "com.example.android://"
@@ -1122,30 +1199,33 @@ Note that the Android URI and iOS Universal Link URLs don’t necessarily use th
         "store_uri": "https://apps.apple.com/app/apple-store/id123456789",
         "discovery_uri": "com.example.ios://"
       }
-    },
-    ...
+    }
+  }
+}
 ```
 
 ##### *station_information.json*
 
 ```jsonc
 {
-  "last_updated":1609866247,
-  "ttl":60,
-  "version":"3.0",
-  "data":{
-    "stations":[
+  "last_updated": 1609866247,
+  "ttl": 60,
+  "version": "3.0",
+  "data": {
+    "stations": [
       {
-        "station_id":"425",
-        "name":"Coppertail",
-        "lat":27.9563335328521,
-        "lon":-82.430436084371,
+        "station_id": "425",
+        "name": "Coppertail",
+        "lat": 27.956333,
+        "lon": -82.430436,
         "rental_uris":{
           "android":"com.example.android://open.example.app/app?sid=1234567890",
           "ios":"com.example.ios://open.example.app/app?sid=1234567890"
         }
-      },
-  ...
+      }
+    ]
+  }
+}
 ```
 
 ##### Example 3 - Deep link web URLs are supported, but not Android or iOS native apps:
@@ -1154,21 +1234,23 @@ Note that the Android URI and iOS Universal Link URLs don’t necessarily use th
 
 ```jsonc
 {
-  "last_updated":1609866247,
-  "ttl":60,
-  "version":"3.0",
-  "data":{
-    "stations":[
+  "last_updated": 1609866247,
+  "ttl": 60,
+  "version": "3.0",
+  "data": {
+    "stations": [
       {
-        "station_id":"425",
-        "name":"Coppertail",
-        "lat":27.9563335328521,
-        "lon":-82.430436084371,
-        "rental_uris":{
-          "web":"https://www.example.com/app?sid=1234567890"
+        "station_id": "425",
+        "name": "Coppertail",
+        "lat": 27.956333,
+        "lon": -82.430436,
+        "rental_uris": {
+          "web": "https://www.example.com/app?sid=1234567890"
         }
-      },
-  ...
+      }
+    ]
+  }
+}
 ```
 
 ## Disclaimers
@@ -1177,4 +1259,4 @@ _Apple Pay, PayPass and other third-party product and service names are trademar
 
 ## License
 
-Except as otherwise noted, the content of this page is licensed under the [Creative Commons Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/).
+Except as otherwise noted, the content of this page is licensed under the [Creative Commons Attribution 3.0 License](https://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
### **What problem does your proposal solve?**

- increase readability of document
- increase readability of document source during editing
- increase consistency across document
- conform to Style Guide and GBFS specification

### **What is the proposal?**

Updated document source, to follow Style Guide:
- separated title sections with new line (not directly in Style Guide, but to increases readability during editing)
- replaced tabs with spaces
- removed unnecessary spaces at line endings and from empty lines

Examples updated to follow GBFS specification and updated formatting:
- unified formatting
- unified parameter values
- link and email domains changed to `example.com`
- added required parameters for feeds
- truncated coordinate precision to 6 decimals (as suggested by specification)
- changed ID type from `integer` to `string` at one place
- removed ellipsis from some examples to make json valid

Protocol of all external links changed to `https`, if target supports it.

I believe also replacing `&nbsp;` elements with space, between dash and parameter name, could clean source a little bit, but it would make PR less readable, so left if for now.

### **Is this a breaking change?**
- [x] No

### **Which files are affected by this change?**
gbfs.md
