### PR TITLE
Add optional station_parking rule to geofencing_zones.json

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -1009,6 +1009,7 @@ Field Name | REQUIRED | Type | Defines
 &emsp;&emsp;&emsp;\-&nbsp;`ride_allowed` | Conditionally REQUIRED | Boolean | REQUIRED if `rules` array is defined. Is the undocked (“free bike”) ride allowed to start and end in this zone? <br /><br /> `true` - Undocked (“free bike”) ride can start and end in this zone. <br /> `false` - Undocked (“free bike”) ride cannot start and end in this zone.
 &emsp;&emsp;&emsp;\-&nbsp;`ride_through_allowed` | Conditionally REQUIRED | Boolean | REQUIRED if `rules` array is defined. Is the ride allowed to travel through this zone? <br /><br /> `true` - Ride can travel through this zone. <br /> `false` - Ride cannot travel through this zone.
 &emsp;&emsp;&emsp;\-&nbsp;`maximum_speed_kph` | OPTIONAL | Non-negative Integer | What is the maximum speed allowed, in kilometers per hour? <br /><br /> If there is no maximum speed to observe, this can be omitted.
+&emsp;&emsp;&emsp;\-&nbsp;`station_parking` | OPTIONAL | Boolean | Vehicle MUST be parked at stations defined in station_information.json within this geofence zone? <br /><br />`true` - MUST only be parked at stations.  <br /> `false` - MAY be parked outside of stations.
 
 ##### Example:
 
@@ -1088,7 +1089,8 @@ Field Name | REQUIRED | Type | Defines
                 ],
                 "ride_allowed": false,
                 "ride_through_allowed": true,
-                "maximum_speed_kph": 10
+                "maximum_speed_kph": 10,
+                "station_parking": true
               }
             ]
           }


### PR DESCRIPTION
#### **What problem does your proposal solve? Please begin with the relevant issue number. If there is no existing issue, please also describe alternative solutions you have considered.**
This PR follows up on the suggestions made by @mplsmitch on https://github.com/NABSA/gbfs/issues/332 (specifically [here](https://github.com/NABSA/gbfs/issues/332#issuecomment-871651849)). 

It is also worth noting that for https://github.com/NABSA/gbfs/issues/332 to be fully resolved, https://github.com/NABSA/gbfs/pull/329 is also needed.

#### **What is the proposal?**
From https://github.com/NABSA/gbfs/issues/332#issuecomment-871651849: 
> The parking restriction could then be defined with a geofencing_zones.json clockwise polygon with a rule applied that outlines the parking restriction.
>
> Suppose we define another rule in `gefoencing_zones.json` like `station_parking`. This could be used to flag zones where parking at a designated area or station is required within the zone. Making it a Boolean would allow you to be explicit about where it is and is not required within your operating area.


#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
`geofencing_zones.json` 