### PR TITLE
Update with the new Json Schema for V2.3-RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Release Candidates will receive *Current Version* status when they have been ful
 
 |  Version | Type  | Release Date |  Status | JSON Schema | Release Notes |
 |:---:|:---:|---|---|---|---|
-|  [v2.3-RC2](https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md) | MINOR  | January 31, 2021 | :white_check_mark: &nbsp; *Release Candidate<br /> (Ready for implementation)*  | *coming soon* | *coming soon* |
-|  [v2.3-RC](https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md) | MINOR  | September 8, 2021 |  *superseded by v2.3-RC2*  | [v2.3-RC Schema](https://github.com/MobilityData/gbfs-json-schema/tree/master/v2.3-RC) | [v2.3-RC Article](https://mobilitydata.org/gbfs-v2-3-rc-is-here-to-fix-some-of-your-problems/) |
+|  [v2.3-RC2](https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md) | MINOR  | January 31, 2021 | :white_check_mark: &nbsp; *Release Candidate<br /> (Ready for implementation)*  | [v2.3-RC2 Schema](https://github.com/MobilityData/gbfs-json-schema/tree/master/v2.3-RC2) | *coming soon* |
+|  [v2.3-RC](https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md) | MINOR  | September 8, 2021 |  *superseded by v2.3-RC2*  | [v2.3-RC Schema](https://github.com/MobilityData/gbfs-json-schema/tree/v3.0.1/v2.3-RC) | [v2.3-RC Article](https://mobilitydata.org/gbfs-v2-3-rc-is-here-to-fix-some-of-your-problems/) |
 
 ### Past Version Releases 
 Past versions with *Supported* status MAY be patched to correct bugs or vulnerabilities but new features will not be introduced.<br />


### PR DESCRIPTION
#### In this PR
- Update the link to the v2.3-RC2.
- Update the link to the v2.3-RC to the accurate tag on the JSON Schema repo because it was replaced by the v2.3-RC2 on the master branch

#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
README.md