### PR TITLE
Update gbfs.md : last_updated description

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -245,7 +245,7 @@ Every JSON file presented in this specification contains the same common header 
 
 Field Name | REQUIRED | Type | Defines
 ---|---|---|---
-`last_updated` | Yes | Timestamp | Indicates the last time data in the feed was updated. This timestamp represents the publisher's knowledge of the current state of the system at this point in time.
+`last_updated` | Yes | Timestamp | Time at which the data in the feed was guaranteed to be up-to-date. This timestamp represents the publisher's knowledge of the current state of the system at this point in time.
 `ttl` | Yes | Non-negative integer | Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).
 `version` | Yes | String | GBFS version number to which the feed conforms, according to the versioning framework.
 `data` | Yes | Object | Response data in the form of name:value pairs.


### PR DESCRIPTION
My name is Francis Chabouis, I work for [transport.data.gouv.fr](transport.data.gouv.fr), the National Access Point of France.

Some of the French GBFS producers seem to update the `last_updated` field rarely in some files, typically `gbfs.json`. This file is not expected to change very often, but an old `last_updated` is difficult to interpret for a user. Does it mean there has been no update on that file for a long time (but it is still up-to-date)? Or is the file stale?

While trying to understand why they published their data that way, I came to read the description of the field in the documentation. And found it slightly misleading. It says "Indicates the last time data in the feed was updated.".  I think this could be interpreted as "Indicates the last time data in the feed was **changed**". This interpretation would allow a data producer to keep an old `last_updated` value, as long as the file content doesn't change.

The second sentence is more explicit: "This timestamp represents the publisher's knowledge of the current state of the system at this point in time."

I propose to modify the first sentence to remove any ambiguity. 

"Time at which the data in the feed was guaranteed to be up-to-date. This timestamp represents the publisher's knowledge of the current state of the system at this point in time."

Feel free to propose any other wording, as English is not my primary language.

#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
None