### PR TITLE
Specify IDs characters range restrictions

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -202,8 +202,8 @@ Example: The `rental_methods` field contains values `creditcard`, `paypass`, etc
 * ID - Should be represented as a string that identifies that particular entity. An ID:
     * MUST be unique within like fields (for example, `station_id` MUST be unique among stations)
     * Does not have to be globally unique, unless otherwise specified
-    * MUST be in the ASCII printable character range, space excluded (0x21 to 0x7E) https://en.wikipedia.org/wiki/ASCII#Printable_characters
-    * SHOULD be restricted to `A-Z`, `a-z`, `0-9` and `.@:/_-`
+    * MUST be in the ASCII printable character range, space excluded (0x21 to 0x7E) https://en.wikipedia.org/wiki/ASCII#Printable_characters *(as of v3.0-RC2)*
+    * SHOULD be restricted to `A-Z`, `a-z`, `0-9` and `.@:/_-` *(as of v3.0-RC2)*
     * MUST be persistent for a given entity (station, plan, etc.). An exception is `vehicle_id`, which MUST NOT be persistent for privacy reasons (see `vehicle_status.json`). *(as of v2.0)*
 * Language - An IETF BCP 47 language code. For an introduction to IETF BCP 47, refer to https://www.rfc-editor.org/rfc/bcp/bcp47.txt and https://www.w3.org/International/articles/language-tags/. Examples: `en` for English, `en-US` for American English, or `de` for German.
 * Latitude - WGS84 latitude in decimal degrees. The value MUST be greater than or equal to -90.0 and less than or equal to 90.0. Example: `41.890169` for the Colosseum in Rome.

--- a/gbfs.md
+++ b/gbfs.md
@@ -202,7 +202,7 @@ Example: The `rental_methods` field contains values `creditcard`, `paypass`, etc
 * ID - Should be represented as a string that identifies that particular entity. An ID:
     * MUST be unique within like fields (for example, `station_id` MUST be unique among stations)
     * Does not have to be globally unique, unless otherwise specified
-    * MUST be in the ASCII printable caracter range, space excluded (0x21 to 0x7E) https://en.wikipedia.org/wiki/ASCII#Printable_characters
+    * MUST be in the ASCII printable character range, space excluded (0x21 to 0x7E) https://en.wikipedia.org/wiki/ASCII#Printable_characters
     * SHOULD be restricted to `A-Z`, `a-z`, `0-9` and `.@:/_-`
     * MUST be persistent for a given entity (station, plan, etc.). An exception is `vehicle_id`, which MUST NOT be persistent for privacy reasons (see `vehicle_status.json`). *(as of v2.0)*
 * Language - An IETF BCP 47 language code. For an introduction to IETF BCP 47, refer to https://www.rfc-editor.org/rfc/bcp/bcp47.txt and https://www.w3.org/International/articles/language-tags/. Examples: `en` for English, `en-US` for American English, or `de` for German.

--- a/gbfs.md
+++ b/gbfs.md
@@ -202,7 +202,8 @@ Example: The `rental_methods` field contains values `creditcard`, `paypass`, etc
 * ID - Should be represented as a string that identifies that particular entity. An ID:
     * MUST be unique within like fields (for example, `station_id` MUST be unique among stations)
     * Does not have to be globally unique, unless otherwise specified
-    * MUST NOT contain spaces
+    * MUST be in the ASCII printable caracter range, space excluded (0x21 to 0x7E) https://en.wikipedia.org/wiki/ASCII#Printable_characters
+    * SHOULD be restricted to `A-Z`, `a-z`, `0-9` and `.@:/_-`
     * MUST be persistent for a given entity (station, plan, etc.). An exception is `vehicle_id`, which MUST NOT be persistent for privacy reasons (see `vehicle_status.json`). *(as of v2.0)*
 * Language - An IETF BCP 47 language code. For an introduction to IETF BCP 47, refer to https://www.rfc-editor.org/rfc/bcp/bcp47.txt and https://www.w3.org/International/articles/language-tags/. Examples: `en` for English, `en-US` for American English, or `de` for German.
 * Latitude - WGS84 latitude in decimal degrees. The value MUST be greater than or equal to -90.0 and less than or equal to 90.0. Example: `41.890169` for the Colosseum in Rome.


### PR DESCRIPTION
This PR clarify and restrict the characters allowed in IDs. See #541 for additional details.

Those edits have multiple goals:
- Clarify the current specification that is too vague
- Ensure interoperability, it MUST be possible to store and compare IDs easily and without pitfall
- Ensure that IDs are easy to manipulate by humans, because even if the format is design for machines, IDs are often used by humans to debug, so they SHOULD be easy to read, write, copy and compare, regardless of the keyboard layout or system used.

With that specification, all IDs present in `system.cvs` should stay compliant (excepts those using spaces `0x20`, who are already not compliant with the current specification).

Also, all others shared mobility systems that I have seen (GBFS or not) are compatible with both restrictions.

Does anyone think that IDs should be restricted further, such as `A-Za-z0-9_-:`? (And consider that existing system that are using `.@/` are compliant because "SHOULD" means "that there may exist valid reasons in particular circumstances to ignore a particular item", and at least "legacy" may fit into that.

Fix #541

#### **Is this a breaking change?**
- [x] Yes

#### **Which files are affected by this change?**
Most of them
