### PR TITLE
Remove redundant formatting in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/new-issue-template.md
@@ -7,15 +7,15 @@ assignees: ''
 
 ---
 
-### **Have you read our [FAQ](https://gbfs.mobilitydata.org/faq)? It’s possible your question can be answered there!**
+### Have you read our [FAQ](https://gbfs.mobilitydata.org/faq)? It’s possible your question can be answered there!
 
-### **If you are new to the specification, please introduce yourself (name and organization/link to GBFS). It’s helpful to know who we're chatting with!** 
+### If you are new to the specification, please introduce yourself (name and organization/link to GBFS). It’s helpful to know who we're chatting with!
 
-### **What is the issue and _why_ is it an issue?**
+### What is the issue and _why_ is it an issue?
 
-### **Please describe some potential solutions you have considered (even if they aren’t related to GBFS).**
+### Please describe some potential solutions you have considered (even if they aren’t related to GBFS).
 
-### **Is your potential solution a breaking change?**
+### Is your potential solution a breaking change?
 - [ ] Yes 
 - [ ] No
 - [ ] Unsure


### PR DESCRIPTION
"###" markdown already applies the bold formatting so "**" is not needed.
