### PR TITLE
Add v3.0-RC2 to the Release Candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Release Candidates will receive *Current Version* status when they have been ful
 
 |  Version | Type  | Release Date   | Status                     | JSON Schema                                                                            | Release Notes       |
 |:---:|:-----:|----------------|----------------------------|----------------------------------------------------------------------------------------|---------------------|
-|[v3.0-RC](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) | MAJOR | March 10, 2023 | ✅ Ready for implementation | [v3.0-RC Schema](https://github.com/MobilityData/gbfs-json-schema/tree/master/v3.0-RC) | [v3.0-RC Article](https://mobilitydata.org/2023-the-year-of-v3/) |
+|[v3.0-RC2](https://github.com/MobilityData/gbfs/blob/master/gbfs.md) | MAJOR | November 14, 2023 | ✅ Ready for implementation | [v3.0-RC Schema](https://github.com/MobilityData/gbfs-json-schema/tree/master/v3.0-RC2) | [v3.0-RC2 Release Notes](https://github.com/MobilityData/gbfs/releases/tag/v3.0-RC2) |
+|[v3.0-RC](https://github.com/MobilityData/gbfs/blob/v3.0-RC/gbfs.md) | MAJOR | March 10, 2023 | ✅ Ready for implementation | [v3.0-RC Schema](https://github.com/MobilityData/gbfs-json-schema/tree/master/v3.0-RC) | [v3.0-RC Article](https://mobilitydata.org/2023-the-year-of-v3/) |
 
 ### Past Version Releases 
 Past versions with *Supported* status MAY be patched to correct bugs or vulnerabilities but new features will not be introduced.<br />

--- a/gbfs.md
+++ b/gbfs.md
@@ -4,7 +4,7 @@ This document explains the types of files and data that comprise the General Bik
 
 ## Reference version
 
-This documentation refers to **v3.0-RC2-Draft (Future Version)**.
+This documentation refers to **v3.0-RC2**.
 
 **For the current version see [**version 2.3**](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md).** For past and upcoming versions see the [README](https://github.com/MobilityData/gbfs/blob/master/README.md#current-version-recommended).
 


### PR DESCRIPTION
Editorial changes:
- Add v3.0-RC2 to the Release Candidates in the README.md
- Remove Draft from v3.0-RC2 in gbfs.md