### PR TITLE
Fix examples

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -674,7 +674,7 @@ Field Name | REQUIRED | Type | Defines
         "model": [
           {
             "text": "Clio",
-            "language": "en",
+            "language": "en"
           }
         ],
         "color": "white",
@@ -1299,7 +1299,7 @@ Field Name | REQUIRED | Type | Defines
             "language": "en"
           }
         ],
-        "last_updated": "2023-07-17T13:34:13+02:00",
+        "last_updated": "2023-07-17T13:34:13+02:00"
       }
     ]
   }

--- a/gbfs.md
+++ b/gbfs.md
@@ -260,7 +260,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 3600,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "name": "Example Bike Rental",
     "system_id": "example_cityname",
@@ -286,7 +286,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "feeds": [
       {
@@ -373,7 +373,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "versions": [
       {
@@ -381,7 +381,7 @@ Field Name | REQUIRED | Type | Defines
         "url": "https://www.example.com/gbfs/2/gbfs"
       },
       {
-        "version": "3.0-RC",
+        "version": "3.0-RC2",
         "url": "https://www.example.com/gbfs/3/gbfs"
       }
     ]
@@ -438,7 +438,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 1800,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "system_id": "example_cityname",
     "languages": ["en"],
@@ -550,7 +550,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "vehicle_types": [
       {
@@ -733,7 +733,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "stations": [
       {
@@ -769,7 +769,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "stations": [
       {
@@ -861,7 +861,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "stations": [
       {
@@ -1065,7 +1065,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 86400,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "regions": [
       {
@@ -1145,7 +1145,7 @@ The user does not pay more than the base price for the first 10 km. After 10 km 
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "plans": [
       {
@@ -1198,7 +1198,7 @@ This example demonstrates a pricing scheme that has a rate both by minute and by
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "plans": [
       {
@@ -1264,7 +1264,7 @@ Field Name | REQUIRED | Type | Defines
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "alerts": [
       {
@@ -1361,7 +1361,7 @@ See examples below.
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "geofencing_zones": {
       "type": "FeatureCollection",
@@ -1647,7 +1647,7 @@ Other supported parameters include:
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "name": [
       {
@@ -1678,7 +1678,7 @@ Other supported parameters include:
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "stations": [
       {
@@ -1706,7 +1706,7 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "name": [
       {
@@ -1737,7 +1737,7 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "stations": [
       {
@@ -1763,7 +1763,7 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 60,
-  "version": "3.0-RC",
+  "version": "3.0-RC2",
   "data": {
     "stations": [
       {

--- a/gbfs.md
+++ b/gbfs.md
@@ -603,7 +603,7 @@ Field Name | REQUIRED | Type | Defines
           "icon_last_modified": "2021-06-15"
         },
         "default_pricing_plan_id": "cargo_plan_1",
-        "pricing_plans_ids": [
+        "pricing_plan_ids": [
           "cargo_plan_1",
           "cargo_plan_2",
           "cargo_plan_3"
@@ -1649,15 +1649,22 @@ Other supported parameters include:
   "ttl": 60,
   "version": "3.0-RC",
   "data": {
-    "name": "Example Bike Rental",
+    "name": [
+      {
+        "text": "Example Bike Rental",
+        "language": "en"
+      }
+    ],
     "system_id": "example_cityname",
     "timezone": "America/Chicago",
     "languages": ["en"],
     "rental_apps": {
       "android": {
+        "store_uri": "https://play.google.com/store/apps/details?id=com.example.android",
         "discovery_uri": "com.example.android://"
       },
       "ios": {
+        "store_uri": "https://apps.apple.com/app/apple-store/id123456789",
         "discovery_uri": "com.example.ios://"
       }
     }
@@ -1701,7 +1708,12 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
   "ttl": 60,
   "version": "3.0-RC",
   "data": {
-    "name": "Example Bike Rental",
+    "name": [
+      {
+        "text": "Example Bike Rental",
+        "language": "en"
+      }
+    ],
     "system_id": "example_cityname",
     "timezone": "America/Chicago",
     "languages": ["en"],

--- a/gbfs.md
+++ b/gbfs.md
@@ -262,7 +262,12 @@ Field Name | REQUIRED | Type | Defines
   "ttl": 3600,
   "version": "3.0-RC2",
   "data": {
-    "name": "Example Bike Rental",
+    "name": [
+      {
+        "text": "Example Bike Rental",
+        "language": "en"
+      }
+    ],
     "system_id": "example_cityname",
     "timezone": "America/Chicago",
     "languages": ["en"]
@@ -1683,7 +1688,12 @@ Other supported parameters include:
     "stations": [
       {
         "station_id": "425",
-        "name": "Coppertail",
+        "name": [
+          {
+            "text": "Coppertail",
+            "language": "en"
+          }
+        ],
         "lat": 27.956333,
         "lon": -82.430436,
         "rental_uris": {
@@ -1742,7 +1752,12 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
     "stations": [
       {
         "station_id": "425",
-        "name": "Coppertail",
+        "name": [
+          {
+            "text": "Coppertail",
+            "language": "en"
+          }
+        ],
         "lat": 27.956333,
         "lon": -82.430436,
         "rental_uris":{
@@ -1768,7 +1783,12 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
     "stations": [
       {
         "station_id": "425",
-        "name": "Coppertail",
+        "name": [
+          {
+            "text": "Coppertail",
+            "language": "en"
+          }
+        ],
         "lat": 27.956333,
         "lon": -82.430436,
         "rental_uris": {


### PR DESCRIPTION
Transferring https://github.com/MobilityData/gbfs/pull/574 to MobilityData repo to fix more typos in the examples.

#### **What is the proposal?**
Fix the examples to makes them valid JSON and conform to the GBFS specification.

#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
Only the examples.