### PR TITLE
chore: remove nextbike_er

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -190,7 +190,6 @@ DE,NEW MöBus nextbike,"Mönchengladbach, DE",nextbike_sn,https://www.nextbike.d
 DE,nextbike Berlin,"Berlin, DE",nextbike_bn,https://www.nextbike.de/de/berlin/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_bn/gbfs.json,
 DE,nextbike Düsseldorf,"Düsseldorf, DE",nextbike_dd,https://www.nextbike.de/de/duesseldorf/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_dd/gbfs.json,
 DE,nextbike Erfurt,"Erfurt, DE",nextbike_ef,https://www.nextbike.de/de/erfurt/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ef/gbfs.json,
-DE,nextbike Erlangen,"Erlangen, DE",nextbike_er,https://www.nextbike.de/de/erlangen/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_er/gbfs.json,
 DE,nextbike Frankfurt,"Frankfurt, DE",nextbike_ff,https://www.nextbike.de/de/frankfurt/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ff/gbfs.json,
 DE,nextbike Gießen,"Gießen, DE",nextbike_ng,https://www.nextbike.de/de/giessen/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ng/gbfs.json,
 DE,nextbike Gütersloh,"Gütersloh, DE",nextbike_dj,https://www.nextbike.de/de/guetersloh/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_dj/gbfs.json,


### PR DESCRIPTION
Removed nextbike_er (Erlangen) since Nextbike itself doesn't operate in the city of Erlangen anymore.

Erlangen, as well as Fürth and Schwabach, will be included in VAG_Rad https://github.com/MobilityData/gbfs/blob/6b92b13b909d0d0d2d158a45a0a236f2200af5d2/systems.csv?plain=1#L226 during the next months, see https://www.vag.de/presse/aktuelle/vag-rad-waechst-leihraeder-kuenftig-auch-in-fuerth-erlangen-und-schwabach-ausbau-zudem-in-nuernbergs-stadtnorden-und-sueden.