### PR TITLE
systems.csv: Removed nextbike_fo from systems.csv

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -315,7 +315,6 @@ FI,Donkey Republic Raasepori,Raasepori,donkey_raasepori,https://www.donkey.bike/
 FI,Donkey Republic Riihimäki,Riihimäki,donkey_riihimaki,https://www.donkey.bike/cities/bike-rental-riihimaki/,https://stables.donkey.bike/api/public/gbfs/2/donkey_riihimaki/gbfs,
 FI,Donkey Republic Turku,Turku,donkey_turku,https://www.donkey.bike/cities/bike-rental-hyvinkaa/,https://stables.donkey.bike/api/public/gbfs/2/donkey_turku/gbfs.json,
 FI,Joe Rauma,Rauma,475,https://www.joescooter.fi/,https://joe.rideatom.com/gbfs/v2_2/en/gbfs?id=475,
-FI,Oulu Poland,Oulu,nextbike_fo,https://kaupunkipyorat.ouka.fi/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_fo/gbfs.json,
 FR,Bicloo,Nantes,nantes,https://www.bicloo.nantesmetropole.fr/en/home,https://transport.data.gouv.fr/gbfs/nantes/gbfs.json,
 FR,Bird Bordeaux,Bordeaux,bird-bordeaux,https://bird.co,https://mds.bird.co/gbfs/v2/public/bordeaux/gbfs.json,
 FR,Bird Castres,Castres,bird-castres,https://bird.co,https://mds.bird.co/gbfs/v2/public/castres/gbfs.json,


### PR DESCRIPTION
Removed nextbike_fo as the bike share system in Oulu, Finland has not been in use since 2019.
