### PR TITLE
Label global_rules field as added in v3.0-RC

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -1340,7 +1340,7 @@ Field Name | REQUIRED | Type | Defines
 `geofencing_zones[].features[].properties.start` | OPTIONAL | Timestamp | Start time of the geofencing zone. If the geofencing zone is always active, this can be omitted.
 `geofencing_zones[].features[].properties.end` | OPTIONAL | Timestamp | End time of the geofencing zone. If the geofencing zone is always active, this can be omitted.
 `geofencing_zones[].features[].properties.rules` | OPTIONAL | Array&lt;[Rule](#geofencing-rule-object)&gt; | Array of [Rule](#geofencing-rule-object) objects defining restrictions that apply within the area of the polygon.  See [Geofencing Rule Precedence](#geofencing-rule-precedence) for details on semantics of overlapping polygons, vehicle types, and other precedence rules.
-`global_rules` | Yes | Array&lt;[Rule](#geofencing-rule-object)&gt; | Array of [Rule](#geofencing-rule-object) objects defining restrictions that apply globally in all areas as the default restrictions, except where overridden with an explicit geofencing zone.  See [Geofencing Rule Precedence](#geofencing-rule-precedence) for more details.<br/>A rule or list of rules, as appropriate, must be specified in the global rules list covering all vehicle types in the feed.
+`global_rules` <br/>*(added in v3.0-RC)* | Yes | Array&lt;[Rule](#geofencing-rule-object)&gt; | Array of [Rule](#geofencing-rule-object) objects defining restrictions that apply globally in all areas as the default restrictions, except where overridden with an explicit geofencing zone.  See [Geofencing Rule Precedence](#geofencing-rule-precedence) for more details.<br/>A rule or list of rules, as appropriate, must be specified in the global rules list covering all vehicle types in the feed.
 
 #### Geofencing Rule Object
 


### PR DESCRIPTION
This editorial change adds a missing label under the field `global_rules` to explain that the field was added in v3.0-RC.

This [Release note](https://github.com/MobilityData/gbfs/releases/tag/v3.0-RC) shows that `global_rules` was added in v3.0-RC by https://github.com/MobilityData/gbfs/pull/481 - Geofencing refactor.