### PR TITLE
Fix markdown formatting for import on gbfs.org

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -9,6 +9,7 @@ Changes to the specification (gbfs.md) and the specification governance (governa
 The specification has a designated Maintainer. The Maintainer MAY be an individual, a group of individuals or an organization. The current Maintainer is [MobilityData](http://mobilitydata.org). The Maintainer role includes but is not limited to: reviewing PRs, maintaining documentation, facilitation and counting of votes, merging successful proposals, managing releases and their [Version Release Cycles](#version-release-cycles). The current Git repository is the [GBFS Github repository](https://github.com/MobilityData/gbfs). The current Slack channel is the #gbfs channel on the [MobilityData Slack](https://mobilitydata-io.slack.com/).
 ### Change Process
 To manage the change process, the following guidelines have been established.
+
 * Anyone can propose a change.
 * A change is proposed by opening a Pull Request (PR) at the GBFS Git repository. The proposer becomes "The Advocate". Comments and feedback from the GBFS community are received to iterate on the proposed change. Discussion lasts for as long as necessary to address questions and revisions, but MUST be at least 7 calendar days.
 * After 7 calendar days, The Advocate or the Maintainer MAY call for a vote. Should The Advocate not call a vote or respond to comments from the community for a period of 30 full calendar days, anyone in the community MAY call for a vote. 


### PR DESCRIPTION
This PR fixes the markdown formatting of governance.md for import on https://gbfs.org/specification/process/

Before | After
-- | --
<img width="1800" alt="image" src="https://github.com/MobilityData/gbfs/assets/2423604/5cea2c1a-9328-4f21-87fe-378618c68504"> | <img width="1800" alt="image" src="https://github.com/MobilityData/gbfs/assets/2423604/e7712a8c-754d-432f-9984-4edac682222c">