### PR TITLE
Fix FAQ URL in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/new-issue-template.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-### Have you read our [FAQ](https://gbfs.mobilitydata.org/faq)? It’s possible your question can be answered there!
+### Have you read our [FAQ](https://gbfs.org/learn/faq/)? It’s possible your question can be answered there!
 
 ### If you are new to the specification, please introduce yourself (name and organization/link to GBFS). It’s helpful to know who we're chatting with!
 


### PR DESCRIPTION
This PR fixes the FAQ URL in the issue template.

Issue mentioned in https://github.com/MobilityData/gbfs/issues/608.

Before | After
-- | --
https://gbfs.mobilitydata.org/faq | https://gbfs.org/learn/faq/
<img width="446" alt="image" src="https://github.com/MobilityData/gbfs/assets/2423604/37d4b10c-ebe3-4971-8767-121b984c2980"> | <img width="832" alt="image" src="https://github.com/MobilityData/gbfs/assets/2423604/fabcbf5a-98f4-4ae8-912a-54e589b6e3e6">