### PR TITLE
Mark system_hours and system_calendar as removed

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -30,8 +30,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     * [station_information.json](#station_informationjson)
     * [station_status.json](#station_statusjson)
     * [vehicle_status.json](#vehicle_statusjson) *(formerly free_bike_status.json)*
-    * [system_hours.json](#system_hoursjson) *(deprecated in v3.0-RC)*
-    * [system_calendar.json](#system_calendarjson) *(deprecated in v3.0-RC)*
+    * [system_hours.json](#system_hoursjson) *(removed in v3.0-RC)*
+    * [system_calendar.json](#system_calendarjson) *(removed in v3.0-RC)*
     * [system_regions.json](#system_regionsjson)
     * [system_pricing_plans.json](#system_pricing_plansjson)
     * [system_alerts.json](#system_alertsjson)
@@ -70,8 +70,8 @@ vehicle_types.json <br/>*(added in v2.1)* | Conditionally REQUIRED | Describes t
 station_information.json | Conditionally REQUIRED | List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.
 station_status.json | Conditionally REQUIRED | Number of available vehicles and docks at each station and station availability. REQUIRED of systems utilizing docks.
 vehicle_status.json | Conditionally REQUIRED | *(as of v2.1)* Describes all vehicles that are not currently in active rental. REQUIRED for free floating (dockless) vehicles. OPTIONAL for station based (docked) vehicles. Vehicles that are part of an active rental MUST NOT appear in this feed.
-system_hours.json | - | This file is deprecated *(as of v3.0-RC)*. See `system_information.opening_hours` for system hours of operation.
-system_calendar.json | - | This file is deprecated *(as of v3.0-RC)*. See `system_information.opening_hours` for system dates of operation.
+system_hours.json | - | This file is removed *(as of v3.0-RC)*. See `system_information.opening_hours` for system hours of operation.
+system_calendar.json | - | This file is removed *(as of v3.0-RC)*. See `system_information.opening_hours` for system dates of operation.
 system_regions.json | OPTIONAL | Regions the system is broken up into.
 system_pricing_plans.json | OPTIONAL | System pricing scheme.
 system_alerts.json | OPTIONAL | Current system alerts.
@@ -1053,11 +1053,11 @@ Field Name | REQUIRED | Type | Defines
 
 ### system_hours.json
 
-This file has been deprecated in v3.0-RC. For earlier versions see the [version history](https://github.com/MobilityData/gbfs/wiki/Complete-Version-History). 
+This file has been removed in v3.0-RC. For earlier versions see the [version history](https://github.com/MobilityData/gbfs/wiki/Complete-Version-History). 
 
 ### system_calendar.json
 
-This file has been deprecated in v3.0-RC. For earlier versions see the [version history](https://github.com/MobilityData/gbfs/wiki/Complete-Version-History). 
+This file has been removed in v3.0-RC. For earlier versions see the [version history](https://github.com/MobilityData/gbfs/wiki/Complete-Version-History). 
 
 ### system_regions.json
 


### PR DESCRIPTION
## Problem
The files system_hours.json and system_calendar.json were removed in https://github.com/MobilityData/gbfs/pull/328. However, the spec says these files were “deprecated”, which usually means permitted, but discouraged.

## Solution
Replace "deprecated” with "removed" about the files system_hours.json and system_calendar.json in the spec.

cc @testower 