### PR TITLE
Remove an extra space in systems.csv

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -813,7 +813,7 @@ US,Spin San Francisco,"San Francisco, CA",provider-null-san_francisco,https://ww
 US,Spin San Marcos,"San Marcos, TX",provider-null-san_marcos,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/san_marcos/gbfs.json,
 US,Spin Santa Monica,"Santa Monica, CA",provider-null-santa_monica,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/santa_monica/gbfs.json,
 US,Spin St George,"St George, UT",provider-null-st_george,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/st_george/gbfs.json,
-US,Spin St. Paul, "St. Paul, MN",provider-null-st_paul,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/st_paul/gbfs.json,
+US,Spin St. Paul,"St. Paul, MN",provider-null-st_paul,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/st_paul/gbfs.json,
 US,Spin Stillwater,"Stillwater, OK",provider-null-stillwater,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/stillwater/gbfs.json,
 US,Spin Tallahassee,"Tallahassee, FL",provider-null-tallahassee,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/tallahassee/gbfs.json,
 US,Spin Tampa,"Tampa, FL",provider-null-tampa,https://www.spin.pm,https://mds.bird.co/gbfs/v2/public/provider/spin/tampa/gbfs.json,


### PR DESCRIPTION
This PR removes an extra space in systems.csv which caused the failure of the workflow `[MobilityData/gbfs] Node.js CI`.

Thanks to @Alessandro100 for noticing this 🙏 

Before | After
-- | --
<img width="592" alt="image" src="https://github.com/MobilityData/gbfs/assets/2423604/19a542a6-6902-4dec-9441-5135c29aa43c"> | <img width="835" alt="image" src="https://github.com/MobilityData/gbfs/assets/2423604/6fb72fbb-b2db-4c44-a361-a53010b86c5e">