### PR TITLE
Fix geofencing example

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -1506,6 +1506,7 @@ See examples below.
                 ],
                 "ride_start_allowed": true,
                 "ride_end_allowed": true,
+                "ride_through_allowed": true,
                 "maximum_speed_kph": 10,
                 "station_parking": true
               }


### PR DESCRIPTION
## Context
I removed the required property `ride_through_allowed` in a [geofencing example](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#geofencing-rule-object) by mistake in https://github.com/MobilityData/gbfs/commit/b9d839042cf0466b4c3c15e02f11515f857b6889.

## What's Changed
This PR adds the missing `ride_through_allowed` property in a geofencing example.