### PR TITLE
Best practice regarding URLs and version upgrades

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -79,7 +79,11 @@ geofencing_zones.json <br/>*(added in v2.1)* | OPTIONAL | Geofencing zones and t
 
 ## Accessibility
 
-Datasets SHOULD be published at an easily accessible, public, permanent URL. (for example, https://www.example.com/gbfs/v3/gbfs.json). The URL SHOULD be directly available without requiring login to access the file to facilitate download by consuming software applications.
+Datasets SHOULD be published at an easily accessible, public, permanent URL. 
+
+The URL SHOULD contain the MAJOR version number. If upgrading to a MINOR version, the URL SHOULD NOT change. (for example, https://www.example.com/gbfs/v3/gbfs.json). 
+
+The URL SHOULD be directly available without requiring login to access the file to facilitate download by consuming software applications.
 
 To be compliant with GBFS, all systems MUST have an entry in the [systems.csv](https://github.com/MobilityData/gbfs/blob/master/systems.csv) file.
 


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs/issues/655

#### **What problem does your proposal solve?**
When a GBFS producer upgrades their feed to a MAJOR version without changing the feed URL, it can break consuming applications.

#### **What is the proposal?**
Add a best practice in the spec to recommend that feed URLs contain the MAJOR version number. eg: https://www.example.com/gbfs/v3/gbfs.json

#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
It does not affect the content of the files, only the URL of the files.

Thank you @AntoineAugusti for raising this issue 🙏 