### PR TITLE
Future availability of vehicle types by station

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -71,7 +71,7 @@ vehicle_types.json <br/>*(added in v2.1)* | Conditionally REQUIRED | Describes t
 station_information.json | Conditionally REQUIRED | List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.
 station_status.json | Conditionally REQUIRED | Number of available vehicles and docks at each station and station availability. REQUIRED of systems utilizing docks.
 vehicle_status.json <br/>*(as of v3.0, formerly free_bike_status.json)* | Conditionally REQUIRED | *(as of v2.1)* Describes all vehicles that are not currently in active rental. REQUIRED for free floating (dockless) vehicles. OPTIONAL for station based (docked) vehicles. Vehicles that are part of an active rental MUST NOT appear in this feed.
-vehicle_type_availability.json <br/>*(added in v3.1-RC2)* | OPTIONAL | Describes the future availability of each vehicle type by station. Useful for systems that allow vehicles to be reserved in advance (e.g. carsharing). OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles.
+vehicle_type_availability.json <br/>*(added in v3.1-RC2)* | OPTIONAL | Describes the future availability of each vehicle type by station. Useful for systems that allow vehicles to be reserved in advance (e.g. carsharing, cargo bike share, etc). OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles.
 system_hours.json | - | This file is removed *(as of v3.0)*. See `system_information.opening_hours` for system hours of operation.
 system_calendar.json | - | This file is removed *(as of v3.0)*. See `system_information.opening_hours` for system dates of operation.
 system_regions.json | OPTIONAL | Regions the system is broken up into.
@@ -1143,7 +1143,7 @@ Field Name | REQUIRED | Type | Defines
 
 *(added in v3.1-RC2)*
 
-Describes the future availability of each vehicle type by station. Useful for systems that allow vehicles to be reserved in advance (e.g. carsharing). OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles. Data returned SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. See [Data Latency](#data-latency).<br/>The following fields are all attributes within the main `data` object for this feed.
+Describes the future availability of each vehicle type by station. Useful for systems that allow vehicles to be reserved in advance (e.g. carsharing, cargo bike share, etc). OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles. Data returned SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. See [Data Latency](#data-latency).<br/>The following fields are all attributes within the main `data` object for this feed.
 
 Field Name | REQUIRED | Type | Defines
 ---|---|---|---

--- a/gbfs.md
+++ b/gbfs.md
@@ -71,7 +71,7 @@ vehicle_types.json <br/>*(added in v2.1)* | Conditionally REQUIRED | Describes t
 station_information.json | Conditionally REQUIRED | List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.
 station_status.json | Conditionally REQUIRED | Number of available vehicles and docks at each station and station availability. REQUIRED of systems utilizing docks.
 vehicle_status.json <br/>*(as of v3.0, formerly free_bike_status.json)* | Conditionally REQUIRED | *(as of v2.1)* Describes all vehicles that are not currently in active rental. REQUIRED for free floating (dockless) vehicles. OPTIONAL for station based (docked) vehicles. Vehicles that are part of an active rental MUST NOT appear in this feed.
-vehicle_type_availability.json <br/>*(added in v3.1-RC2)* | OPTIONAL | Describes the future availability of each vehicle type by station. OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles.
+vehicle_type_availability.json <br/>*(added in v3.1-RC2)* | OPTIONAL | Describes the future availability of each vehicle type by station. Useful for systems that allow vehicles to be reserved in advance (e.g. carsharing). OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles.
 system_hours.json | - | This file is removed *(as of v3.0)*. See `system_information.opening_hours` for system hours of operation.
 system_calendar.json | - | This file is removed *(as of v3.0)*. See `system_information.opening_hours` for system dates of operation.
 system_regions.json | OPTIONAL | Regions the system is broken up into.
@@ -1143,7 +1143,7 @@ Field Name | REQUIRED | Type | Defines
 
 *(added in v3.1-RC2)*
 
-Describes the future availability of each vehicle type by station. OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles. Data returned SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. See [Data Latency](#data-latency).<br/>The following fields are all attributes within the main `data` object for this feed.
+Describes the future availability of each vehicle type by station. Useful for systems that allow vehicles to be reserved in advance (e.g. carsharing). OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles. Data returned SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. See [Data Latency](#data-latency).<br/>The following fields are all attributes within the main `data` object for this feed.
 
 Field Name | REQUIRED | Type | Defines
 ---|---|---|---

--- a/gbfs.md
+++ b/gbfs.md
@@ -30,6 +30,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     * [station_information.json](#station_informationjson)
     * [station_status.json](#station_statusjson)
     * [vehicle_status.json](#vehicle_statusjson) *(formerly free_bike_status.json)*
+    * [vehicle_type_availability.json](#vehicle_type_availabilityjson) *(added in v3.1-RC2)*
     * [system_hours.json](#system_hoursjson) *(removed in v3.0)*
     * [system_calendar.json](#system_calendarjson) *(removed in v3.0)*
     * [system_regions.json](#system_regionsjson)
@@ -70,6 +71,7 @@ vehicle_types.json <br/>*(added in v2.1)* | Conditionally REQUIRED | Describes t
 station_information.json | Conditionally REQUIRED | List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.
 station_status.json | Conditionally REQUIRED | Number of available vehicles and docks at each station and station availability. REQUIRED of systems utilizing docks.
 vehicle_status.json <br/>*(as of v3.0, formerly free_bike_status.json)* | Conditionally REQUIRED | *(as of v2.1)* Describes all vehicles that are not currently in active rental. REQUIRED for free floating (dockless) vehicles. OPTIONAL for station based (docked) vehicles. Vehicles that are part of an active rental MUST NOT appear in this feed.
+vehicle_type_availability.json <br/>*(added in v3.1-RC2)* | OPTIONAL | Describes the future availability of each vehicle type by station. OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles.
 system_hours.json | - | This file is removed *(as of v3.0)*. See `system_information.opening_hours` for system hours of operation.
 system_calendar.json | - | This file is removed *(as of v3.0)*. See `system_information.opening_hours` for system dates of operation.
 system_regions.json | OPTIONAL | Regions the system is broken up into.
@@ -1130,6 +1132,48 @@ Field Name | REQUIRED | Type | Defines
         "home_station_id":"146",
         "vehicle_equipment":[
           "child_seat_a"
+        ]
+      }
+    ]
+  }
+}
+```
+
+### vehicle_type_availability.json
+
+*(added in v3.1-RC2)*
+
+Describes the future availability of each vehicle type by station. OPTIONAL for station based (docked) vehicles. Not supported for free floating (dockless) vehicles. Data returned SHOULD be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. See [Data Latency](#data-latency).<br/>The following fields are all attributes within the main `data` object for this feed.
+
+Field Name | REQUIRED | Type | Defines
+---|---|---|---
+`vehicle_types` | REQUIRED | Array&lt;Object&gt; | Contains one object per vehicle type.
+`vehicle_types[].vehicle_type_id` | REQUIRED | ID | Unique identifier of a vehicle type as defined in [vehicle_types.json](#vehicle_typesjson).
+`vehicle_types[].availability[]` | REQUIRED | Array&lt;Object&gt; | Array of availability for the specified vehicle type.
+`vehicle_types[].availability[].station_id` | REQUIRED | ID | Unique identifier of a station as defined in [station_information.json](#station_informationjson).
+`vehicle_types[].availability[].time_slots[]` | REQUIRED | Array&lt;Object&gt; | Array of time slots during which at least one vehicle of the specified type is available at this station. The same vehicle must be available for the entire duration of the time slot.
+`vehicle_types[].availability[].time_slots[].from` | REQUIRED | Datetime | Start date and time of available time slot.
+`vehicle_types[].availability[].time_slots[].until` | REQUIRED | Datetime | End date and time of available time slot.
+
+**Example**
+
+```json
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.1-RC2",
+  "data": {
+    "vehicle_types": [
+      {
+        "vehicle_type_id": "abc123",
+        "availability": [
+          { 
+            "station_id": "station1",
+            "time_slots": [ //intervals can overlap
+              {"from": "2024-12-24T08:15Z", "until": "2024-12-24T09:15Z" },
+              {"from": "2024-12-24T08:45Z", "until": "2024-12-24T10:00Z" }
+            ]
+          },
         ]
       }
     ]

--- a/gbfs.md
+++ b/gbfs.md
@@ -1151,7 +1151,7 @@ Field Name | REQUIRED | Type | Defines
 `vehicle_types[].vehicle_type_id` | REQUIRED | ID | Unique identifier of a vehicle type as defined in [vehicle_types.json](#vehicle_typesjson).
 `vehicle_types[].availability[]` | REQUIRED | Array&lt;Object&gt; | Array of availability for the specified vehicle type.
 `vehicle_types[].availability[].station_id` | REQUIRED | ID | Unique identifier of a station as defined in [station_information.json](#station_informationjson).
-`vehicle_types[].availability[].time_slots[]` | REQUIRED | Array&lt;Object&gt; | Array of time slots during which at least one vehicle of the specified type is available at this station. The same vehicle must be available for the entire duration of the time slot.
+`vehicle_types[].availability[].time_slots[]` | REQUIRED | Array&lt;Object&gt; | Array of time slots during which at least one vehicle of the specified type is available at this station. The same vehicle must be available for the entire duration of the time slot. The time slots intervals can overlap.
 `vehicle_types[].availability[].time_slots[].from` | REQUIRED | Datetime | Start date and time of available time slot.
 `vehicle_types[].availability[].time_slots[].until` | REQUIRED | Datetime | End date and time of available time slot.
 
@@ -1169,9 +1169,15 @@ Field Name | REQUIRED | Type | Defines
         "availability": [
           { 
             "station_id": "station1",
-            "time_slots": [ //intervals can overlap
-              {"from": "2024-12-24T08:15Z", "until": "2024-12-24T09:15Z" },
-              {"from": "2024-12-24T08:45Z", "until": "2024-12-24T10:00Z" }
+            "time_slots": [
+              {
+                "from": "2024-12-24T08:15Z",
+                "until": "2024-12-24T09:15Z"
+              },
+              {
+                "from": "2024-12-24T08:45Z",
+                "until": "2024-12-24T10:00Z"
+              }
             ]
           }
         ]

--- a/gbfs.md
+++ b/gbfs.md
@@ -1153,7 +1153,7 @@ Field Name | REQUIRED | Type | Defines
 `vehicle_types[].availability[].station_id` | REQUIRED | ID | Unique identifier of a station as defined in [station_information.json](#station_informationjson).
 `vehicle_types[].availability[].time_slots[]` | REQUIRED | Array&lt;Object&gt; | Array of time slots during which at least one vehicle of the specified type is available at this station. The same vehicle must be available for the entire duration of the time slot. The time slots intervals can overlap.
 `vehicle_types[].availability[].time_slots[].from` | REQUIRED | Datetime | Start date and time of available time slot.
-`vehicle_types[].availability[].time_slots[].until` | REQUIRED | Datetime | End date and time of available time slot.
+`vehicle_types[].availability[].time_slots[].until` | OPTIONAL | Datetime | End date and time of available time slot. If this field is empty, it means that the vehicle type is available all the time from the date in the `from` field.
 
 **Example**
 
@@ -1175,8 +1175,7 @@ Field Name | REQUIRED | Type | Defines
                 "until": "2024-12-24T09:15Z"
               },
               {
-                "from": "2024-12-24T08:45Z",
-                "until": "2024-12-24T10:00Z"
+                "from": "2024-12-24T08:45Z"
               }
             ]
           }

--- a/gbfs.md
+++ b/gbfs.md
@@ -1173,7 +1173,7 @@ Field Name | REQUIRED | Type | Defines
               {"from": "2024-12-24T08:15Z", "until": "2024-12-24T09:15Z" },
               {"from": "2024-12-24T08:45Z", "until": "2024-12-24T10:00Z" }
             ]
-          },
+          }
         ]
       }
     ]


### PR DESCRIPTION
#### **What problem does your proposal solve? Please begin with the relevant issue number. If there is no existing issue, please also describe alternative solutions you have considered.**
Following the discussion in https://github.com/MobilityData/gbfs/issues/616

Operators want to be able to describe the future availability of their services, for example to display it in trip planners. This is particularly useful for systems that allow vehicles to be booked in advance (e.g. carsharing).

#### **What is the proposal?**
Add a new endpoint `vehicle_type_availability.json` which describes the future availability of each vehicle type by station.

#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
Proposal to add a new endpoint: `vehicle_type_availability.json`