### PR TITLE
Add missing column for Citiz feed in systems.csv

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -499,7 +499,7 @@ FR,Citiz AUPA,Bayonne,aupa,https://citiz.coop/,https://backend.citiz.fr/public/p
 FR,Citiz Alpes Loire,Grenoble,citiz_alpes_loire,https://citiz.coop/,https://backend.citiz.fr/public/provider/5/gbfs/v3.0/gbfs.json,3.0,
 FR,Citiz Angers,Angers,citiz_angers,https://citiz.coop/,https://backend.citiz.fr/public/provider/7/gbfs/v3.0/gbfs.json,3.0,
 FR,Citiz BFC,Besançon,citiz_bfc,https://citiz.coop/,https://backend.citiz.fr/public/provider/2/gbfs/v3.0/gbfs.json,3.0,
-FR,Citiz Développement,France,citiz_developpement,https://citiz.coop/,https://backend.citiz.fr/public/provider/12/gbfs/3.0/gbfs.json,3.0
+FR,Citiz Développement,France,citiz_developpement,https://citiz.coop/,https://backend.citiz.fr/public/provider/12/gbfs/3.0/gbfs.json,3.0,
 FR,Citiz Gironde,Bordeaux,citiz_gironde,https://citiz.coop/,https://backend.citiz.fr/public/provider/4/gbfs/v3.0/gbfs.json,3.0,
 FR,Citiz Grand Est,Strasbourg,citiz_grand_est,https://citiz.coop/,https://backend.citiz.fr/public/provider/1/gbfs/v3.0/gbfs.json,3.0,
 FR,Citiz Grand Poitiers,Poitiers,citiz_grand_poitiers,https://citiz.coop/,https://backend.citiz.fr/public/provider/9/gbfs/v3.0/gbfs.json,3.0,


### PR DESCRIPTION
## What's Changed
Follow up of https://github.com/MobilityData/gbfs/pull/727

This PR adds a missing comma at the end of the row for Citiz Développement. 

It's my fault, I overlooked this in the initial pull request.