### PR TITLE
Update TTL values in spec examples

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -268,7 +268,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 3600,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "name": [
@@ -299,7 +299,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "feeds": [
@@ -337,7 +337,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl":0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data":{
     "datasets":[
@@ -468,7 +468,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "versions": [
@@ -533,7 +533,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 1800,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "system_id": "example_cityname",
@@ -645,7 +645,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "vehicle_types": [
@@ -828,7 +828,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "stations": [
@@ -864,7 +864,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "stations": [
@@ -1059,7 +1059,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl":0,
+  "ttl": 0,
   "version": "3.1-RC",
   "data":{
     "vehicles":[
@@ -1097,7 +1097,7 @@ Field Name | REQUIRED | Type | Defines
 
  {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl":0,
+  "ttl": 0,
   "version": "3.1-RC",
   "data":{
     "vehicles":[
@@ -1160,7 +1160,7 @@ Field Name | REQUIRED | Type | Defines
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 86400,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "regions": [
@@ -1240,7 +1240,7 @@ The user does not pay more than the base price for the first 10 km. After 10 km 
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "plans": [
@@ -1293,7 +1293,7 @@ This example demonstrates a pricing scheme that has a rate both by minute and by
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 0,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "plans": [
@@ -1456,7 +1456,7 @@ See examples below.
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 60,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "geofencing_zones": {
@@ -1718,7 +1718,7 @@ Other supported parameters include:
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 60,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "name": [
@@ -1749,7 +1749,7 @@ Other supported parameters include:
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 60,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "stations": [
@@ -1782,7 +1782,7 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 60,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "name": [
@@ -1813,7 +1813,7 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 60,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "stations": [
@@ -1844,7 +1844,7 @@ Note that the Android URI and iOS Universal Link URLs do not necessarily use the
 ```json
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
-  "ttl": 60,
+  "ttl": 300,
   "version": "3.1-RC",
   "data": {
     "stations": [


### PR DESCRIPTION
## Context
During a workshop at the 2024 MobilityData Summit in Montreal, participants reported that the TTL (Time to Live) values in the spec examples did not show good practice. This PR aims to correct this.

TTL is used to improve the performance and manage the caching of data.

## What's Changed
The TTL values in the spec examples were updated as follows:

Non-real-time files:
File | Before | After
-- | -- | --
[gbfs.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#gbfsjson) | 0 sec | 300 sec
[manifest.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#manifestjson) | 0 sec | 300 sec
[gbfs_versions.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#gbfs_versionsjson) | 0 sec | 300 sec
[system_information.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_informationjson) | 1800 sec | 300 sec
[vehicle_types.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_typesjson) | 0 sec | 300 sec
[station_information.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_informationjson) | 0 sec | 300 sec
[system_regions.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_regionsjson) | 86400 sec | 300 sec
[system_pricing_plans.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_pricing_plansjson) | 0 sec | 300 sec
[geofencing_zones.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#geofencing_zonesjson) | 60 sec | 300 sec

Real-time files (no change):
File | Before | After
-- | -- | --
[station_status.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#station_statusjson) | 0 sec | 0 sec
[vehicle_status.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_statusjson) | 0 sec | 0 sec

Close to real-time file (no change):
File | Before | After
-- | -- | --
[system_alerts.json](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_alertsjson) | 60 sec | 60 sec

## Acknowledgements
Thanks to the Montreal workshop participants and the community for contributing to the GBFS spec 🙏 

Upcoming [GBFS workshop](https://www.linkedin.com/posts/mobilitydata_save-the-dates-were-thrilled-to-activity-7298009760740589569-gvJ9) dates:

- Paris, France: June 24-25, 2025
- Los Angeles, USA: October 7-8, 2025