### PR TITLE
Sync systems.csv with the Swiss catalog

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -130,6 +130,7 @@ CH,Lime Opfikon,Opfikon,lime_opfikon,https://www.li.me/,https://data.lime.bike/a
 CH,Lime Basel,Basel,lime_basel,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_basel/gbfs,2.3,
 CH,Lime Uster,Uster,lime_uster,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_uster/gbfs,2.3,
 CH,Lime Wetzikon,Wetzikon,lime_wetzikon,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_wetzikon/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
+CH,Lime Winterthur,Winterthur,lime_winterthur,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_winterthur/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
 CH,Lime Zug,Zug,lime_zug,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json,2.2,
 CH,Lime Zurich,Zurich,lime_zurich,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_zurich/gbfs,2.3,
 CH,LINK Basel,Basel,Link_Basel,https://www.superpedestrian.com,https://mds.linkyour.city/gbfs/ch_basel/gbfs.json,2.2 ; 2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -100,7 +100,7 @@ CA,Neuron Mobility,Vernon,neuron_yve,https://www.rideneuron.com,https://mds.neur
 CA,PBSC HQ,Montreal,pbsn,https://lyfturbansolutions.com/cities,https://pbsn.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,
 CA,Sobi Hamilton,Hamilton,sobi_hamilton,https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json,1.0,
 CA,UBC,UBC - Canada,13,https://gohopr.com/,https://gbfs.hopr.city/api/gbfs/13,2.2,
-CH,2EM Car Sharing,Switzerland,zem_ch,https://www.2em.ch,https://api.mobidata-bw.de/sharing/gbfs/zem_ch/gbfs,2.3,
+CH,2EM Car Sharing,Switzerland,2em_cars,https://www.2em.ch,https://gbfs.prod.sharedmobility.ch/v2/gbfs/2em_cars/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
 CH,Bird Basel,Basel,bird-basel,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/basel/gbfs.json,1.1 ; 2.3,
 CH,Bird Biel,Biel,bird-biel,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/biel/gbfs.json,1.1 ; 2.3,
 CH,Bird Bulle,Bulle,bird-bulle,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/bulle/gbfs.json,1.1 ; 2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -129,6 +129,7 @@ CH,edrive carsharing,Switzerland,edrivecarsharing_ch,https://www.edrivecarsharin
 CH,Lime Opfikon,Opfikon,lime_opfikon,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/opfikon/gbfs.json,2.2,
 CH,Lime Basel,Basel,lime_basel,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_basel/gbfs,2.3,
 CH,Lime Uster,Uster,lime_uster,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_uster/gbfs,2.3,
+CH,Lime Wetzikon,Wetzikon,lime_wetzikon,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_wetzikon/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
 CH,Lime Zug,Zug,lime_zug,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json,2.2,
 CH,Lime Zurich,Zurich,lime_zurich,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_zurich/gbfs,2.3,
 CH,LINK Basel,Basel,Link_Basel,https://www.superpedestrian.com,https://mds.linkyour.city/gbfs/ch_basel/gbfs.json,2.2 ; 2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -104,6 +104,7 @@ CH,2EM Car Sharing,Switzerland,2em_cars,https://www.2em.ch,https://gbfs.prod.sha
 CH,Bird Basel,Basel,bird-basel,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/basel/gbfs.json,1.1 ; 2.3,
 CH,Bird Biel,Biel,bird-biel,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/biel/gbfs.json,1.1 ; 2.3,
 CH,Bird Bulle,Bulle,bird-bulle,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/bulle/gbfs.json,1.1 ; 2.3,
+CH,Bird Grenchen,Grenchen,bird-grenchen,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/grenchen/gbfs.json,1.1 ; 2.3,
 CH,Bird Kloten,Kloten,bird-kloten,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/kloten/gbfs.json,1.1 ; 2.3,
 CH,Bird Uster,Uster,bird-uster,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/uster/gbfs.json,1.1 ; 2.3,
 CH,Bird Winterthur,Winterthur,bird-winterthur,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/winterthur/gbfs.json,1.1 ; 2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -134,6 +134,7 @@ CH,Lime Winterthur,Winterthur,lime_winterthur,https://www.li.me/,https://gbfs.pr
 CH,Lime Zug,Zug,lime_zug,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json,2.2,
 CH,Lime Zurich,Zurich,lime_zurich,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/lime_zurich/gbfs,2.3,
 CH,LINK Basel,Basel,Link_Basel,https://www.superpedestrian.com,https://mds.linkyour.city/gbfs/ch_basel/gbfs.json,2.2 ; 2.3,
+CH,Mobility,Switzerland,mobility,https://www.mobility.ch,https://gbfs.prod.sharedmobility.ch/v2/gbfs/mobility/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
 CH,nextbike Switzerland,Switzerland,nextbike_ch,https://www.nextbike.ch/de/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ch/gbfs.json,2.3,
 CH,PubliBike,Switzerland,publibike,https://www.publibike.ch,https://api.publibike.ch/v1/gbfs/v2/gbfs.json,2.3,
 CH,PickeBike Aubonne,Aubonne,pickebike_aubonne,https://www.pickebike.ch/de/,https://api.mobidata-bw.de/sharing/gbfs/pickebike_aubonne/gbfs,2.3,


### PR DESCRIPTION
## Whats Changed

This PR syncs [systems.csv](https://github.com/MobilityData/gbfs/blob/master/systems.csv) with the Swiss GBFS catalog (https://sharedmobility.ch/v2/gbfs?Authorization=gbfs@sharedmobility.ch):
- Updated 1 feed for 2EM Car Sharing Switzerland
- Added 4 feeds (Bird, Lime x2, and Mobility carsharing)

Please note that the feeds hosted by the [Swiss Federal Platform](https://github.com/SFOE/sharedmobility/blob/main/Access%20the%20data.md) require adding a URL parameter to the endpoints: e.g. https://gbfs.prod.sharedmobility.ch/v2/gbfs/2em_cars/gbfs?Authorization=gbfs@sharedmobility.ch

Thanks @ue71603 for your help 🙏 