### PR TITLE
Sync systems.csv with the French NAP

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -606,7 +606,7 @@ FR,Vélivert,Saint-Étienne,velivert_saint_etienne,https://www.velivert.fr/,http
 FR,VélYcéo,Saint-Nazaire,velyceo,https://velyceo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/velyceo/gbfs.json,2.2 ; 3.0,
 FR,Vernou Vélo,Vernou-en-Sologne,vernouvelo,https://vernouvelo.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/vernouvelo/gbfs.json,2.2 ; 3.0,
 FR,Vertuose,Longwy,vertuose,https://vertuose.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/vertuose/gbfs.json,2.2 ; 3.0,
-FR,V'lille,Lille,vlille,https://www.ilevia.fr/cms/vlille/,https://transport.data.gouv.fr/gbfs/vlille/gbfs.json,,
+FR,V'lille,Lille,v_lille,https://www.ilevia.fr/v-lille,https://media.ilevia.fr/opendata/gbfs.json,2.3,
 FR,Voi Marseille,Marseille,voi_Marseille,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/66/gbfs.json,2.3,
 FR,Zebullo,Reims,zebullo,https://zebullo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/zebullo/gbfs.json,2.2 ; 3.0,
 GB,BelfastBikes,Belfast,nextbike_bu,https://www.belfastbikes.co.uk/en/belfast/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_bu/gbfs.json,2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -598,7 +598,7 @@ FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?
 FR,Vélopop,Avignon,velopop,https://velo-grandavignon.fr/fr/,https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/avignon/gbfs.json,1.0,key=NWNiMjc5YmQtMzVlOC00MmJiLTkyYTItNzZkMDViMzA2MzA2
 FR,VélOstan'lib,Nancy,nancy,https://www.velostanlib.fr/,https://api.cyclocity.fr/contracts/nancy/gbfs/gbfs.json,2.3,
 FR,VélÔToulouse,Toulouse,toulouse,http://www.velo.toulouse.fr/,https://api.cyclocity.fr/contracts/toulouse/gbfs/gbfs.json,2.3,
-FR,VéloZef,Brest,velozef,https://www.bibus.fr/services/velozef-le-velo-assistance-electrique-en-libre-service,https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/gbfs.json,1.0,key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx
+FR,VéloZef,Brest,velozef,https://www.bibus.fr/services/velozef-le-velo-assistance-electrique-en-libre-service,https://gbfs.partners.fifteen.eu/gbfs/2.2/brest/en/gbfs.json,2.2,
 FR,Vélo'Cité,Laon,velocite,https://velocite.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/velocite/gbfs.json,2.2 ; 3.0,
 FR,Vélo'v,Lyon,lyon,https://velov.grandlyon.com/en/home,https://api.cyclocity.fr/contracts/lyon/gbfs/gbfs.json,2.3,
 FR,Vélibéo,Brive-la-Gaillarde,velibeo,https://velibeo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/velibeo/gbfs.json,2.2 ; 3.0,

--- a/systems.csv
+++ b/systems.csv
@@ -489,6 +489,7 @@ FI,Donkey Republic Riihimäki,Riihimäki,donkey_riihimaki,https://www.donkey.bik
 FI,Donkey Republic Turku,Turku,donkey_turku,https://www.donkey.bike/cities/bike-rental-hyvinkaa/,https://stables.donkey.bike/api/public/gbfs/2/donkey_turku/gbfs.json,1.0 ; 2.3,
 FI,Joe Rauma,Rauma,475,https://www.joescooter.fi/,https://joe.rideatom.com/gbfs/v2_2/en/gbfs?id=475,2.2,
 FR,Altervelo Libre-service,"Saint-Pierre, L'Étang-Salé & Saint-Louis",altervelo,https://altervelo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/altervelo/gbfs.json,2.2 ; 3.0,
+FR,AQTA,Auray,auray-quiberon,https://www.auray-quiberon.fr/,https://gbfs.partners.fifteen.eu/gbfs/auray-quiberon/gbfs.json,2.2,
 FR,Bird Bordeaux,Bordeaux,bird-bordeaux,https://bird.co,https://mds.bird.co/gbfs/v2/public/bordeaux/gbfs.json,1.1 ; 2.3,
 FR,Bird Castres,Castres,bird-castres,https://bird.co,https://mds.bird.co/gbfs/v2/public/castres/gbfs.json,1.1 ; 2.3,
 FR,Bird Chalonsenchampagne,Châlons-en-Champagne,bird-chalonsenchampagne,https://bird.co,https://mds.bird.co/gbfs/v2/public/chalonsenchampagne/gbfs.json,1.1 ; 2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -608,6 +608,7 @@ FR,VélYcéo,Saint-Nazaire,velyceo,https://velyceo.ecovelo.mobi,https://api.gbfs
 FR,Vernou Vélo,Vernou-en-Sologne,vernouvelo,https://vernouvelo.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/vernouvelo/gbfs.json,2.2 ; 3.0,
 FR,Vertuose,Longwy,vertuose,https://vertuose.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/vertuose/gbfs.json,2.2 ; 3.0,
 FR,V'lille,Lille,v_lille,https://www.ilevia.fr/v-lille,https://media.ilevia.fr/opendata/gbfs.json,2.3,
+FR,Voi Le Havre,Le Havre,voi_Le_Havre,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/336/gbfs.json,2.3,
 FR,Voi Marseille,Marseille,voi_Marseille,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/66/gbfs.json,2.3,
 FR,Zebullo,Reims,zebullo,https://zebullo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/zebullo/gbfs.json,2.2 ; 3.0,
 GB,BelfastBikes,Belfast,nextbike_bu,https://www.belfastbikes.co.uk/en/belfast/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_bu/gbfs.json,2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -562,6 +562,7 @@ FR,Naolib,Nantes,nantes,https://velo.naolib.fr/,https://api.cyclocity.fr/contrac
 FR,Naolib Micromob',Chantrerie,chantrerie,https://naolib.fr/fr/velos/micromob-1,https://api.gbfs.v3.0.ecovelo.mobi/chantrerie/gbfs.json,2.2 ; 3.0,
 FR,Ogalo Cyclette,Saumur,ogalo,https://ogalo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/ogalo/gbfs.json,2.2 ; 3.0,
 FR,Optymo Belfort,Belfort,Optymo_FR_Belfort,https://www.optymo.fr/,https://belfort-gbfs.klervi.net/gbfs/gbfs.json,,
+FR,Optymo Belfort Auto libre-service,Belfort,Optymo_Belfort_ALS,https://www.optymo.fr/,https://data.optymo.fr/als/gbfs.json,2.3,
 FR,Pony Angers,Angers,pony_Angers,https://getapony.com/,https://gbfs.getapony.com/v1/angers/en/gbfs.json,2.2,
 FR,Pony Basque Country,Basque Country,pony_Basque_Country,https://getapony.com/,https://gbfs.getapony.com/v1/basque_country/en/gbfs.json,2.2,
 FR,Pony Beauvais,Beauvais,pony_Beauvais,https://getapony.com/,https://gbfs.getapony.com/v1/beauvais/en/gbfs.json,2.2,

--- a/systems.csv
+++ b/systems.csv
@@ -607,6 +607,7 @@ FR,Vélivert,Saint-Étienne,velivert_saint_etienne,https://www.velivert.fr/,http
 FR,VélYcéo,Saint-Nazaire,velyceo,https://velyceo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/velyceo/gbfs.json,2.2 ; 3.0,
 FR,Vernou Vélo,Vernou-en-Sologne,vernouvelo,https://vernouvelo.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/vernouvelo/gbfs.json,2.2 ; 3.0,
 FR,Vertuose,Longwy,vertuose,https://vertuose.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/vertuose/gbfs.json,2.2 ; 3.0,
+FR,Vilvolt,Épinal,vilvolt_epinal,https://vilvolt.fr/,https://gbfs.partners.fifteen.eu/gbfs/epinal/gbfs.json,2.2,
 FR,V'lille,Lille,v_lille,https://www.ilevia.fr/v-lille,https://media.ilevia.fr/opendata/gbfs.json,2.3,
 FR,Voi Le Havre,Le Havre,voi_Le_Havre,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/336/gbfs.json,2.3,
 FR,Voi Marseille,Marseille,voi_Marseille,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/66/gbfs.json,2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -594,7 +594,7 @@ FR,Vélo'Baie,Saint-Brieuc,saintbrieuc,https://www.saintbrieuc-armor-agglo.bzh/v
 FR,Vélocéo,Vannes,Veloceo_FR_Vannes,https://veloceo.kiceo.fr/,https://vannes-gbfs.klervi.net/gbfs/gbfs.json,,
 FR,VéloCité,Besançon,besancon,https://www.velocite.besancon.fr/,https://api.cyclocity.fr/contracts/besancon/gbfs/gbfs.json,2.3,
 FR,VéloCité,Mulhouse,mulhouse,https://www.compte-mobilite.fr/services/velos-en-libre-service/,https://api.cyclocity.fr/contracts/mulhouse/gbfs/gbfs.json,2.3,
-FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?rub_code=1&thm_id=6,https://montpellier-fr-smoove.klervi.net/gbfs/gbfs.json,,
+FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?rub_code=1&thm_id=6,https://montpellier-fr.fifteen.site/gbfs/gbfs.json,1.0,
 FR,Vélopop,Avignon,velopop,https://velo-grandavignon.fr/fr/,https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/avignon/gbfs.json,1.0,key=NWNiMjc5YmQtMzVlOC00MmJiLTkyYTItNzZkMDViMzA2MzA2
 FR,VélOstan'lib,Nancy,nancy,https://www.velostanlib.fr/,https://api.cyclocity.fr/contracts/nancy/gbfs/gbfs.json,2.3,
 FR,VélÔToulouse,Toulouse,toulouse,http://www.velo.toulouse.fr/,https://api.cyclocity.fr/contracts/toulouse/gbfs/gbfs.json,2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -562,7 +562,7 @@ FR,LOVELO Libre-service,Rouen,inurba-rouen,https://lovelolibreservice.fr/,https:
 FR,Naolib,Nantes,nantes,https://velo.naolib.fr/,https://api.cyclocity.fr/contracts/nantes/gbfs/gbfs.json,2.3,
 FR,Naolib Micromob',Chantrerie,chantrerie,https://naolib.fr/fr/velos/micromob-1,https://api.gbfs.v3.0.ecovelo.mobi/chantrerie/gbfs.json,2.2 ; 3.0,
 FR,Ogalo Cyclette,Saumur,ogalo,https://ogalo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/ogalo/gbfs.json,2.2 ; 3.0,
-FR,Optymo Belfort,Belfort,Optymo_FR_Belfort,https://www.optymo.fr/,https://belfort-gbfs.klervi.net/gbfs/gbfs.json,,
+FR,Optymo Belfort,Belfort,Optymo_FR_Belfort,https://www.optymo.fr/,https://data.optymo.fr/vls/gbfs.json,1.0,
 FR,Optymo Belfort Auto libre-service,Belfort,Optymo_Belfort_ALS,https://www.optymo.fr/,https://data.optymo.fr/als/gbfs.json,2.3,
 FR,Pony Angers,Angers,pony_Angers,https://getapony.com/,https://gbfs.getapony.com/v1/angers/en/gbfs.json,2.2,
 FR,Pony Basque Country,Basque Country,pony_Basque_Country,https://getapony.com/,https://gbfs.getapony.com/v1/basque_country/en/gbfs.json,2.2,

--- a/systems.csv
+++ b/systems.csv
@@ -609,6 +609,7 @@ FR,VélYcéo,Saint-Nazaire,velyceo,https://velyceo.ecovelo.mobi,https://api.gbfs
 FR,Vernou Vélo,Vernou-en-Sologne,vernouvelo,https://vernouvelo.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/vernouvelo/gbfs.json,2.2 ; 3.0,
 FR,Vertuose,Longwy,vertuose,https://vertuose.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/vertuose/gbfs.json,2.2 ; 3.0,
 FR,Vilvolt,Épinal,vilvolt_epinal,https://vilvolt.fr/,https://gbfs.partners.fifteen.eu/gbfs/epinal/gbfs.json,2.2,
+FR,Vivélo,Vichy,vivelo,https://www.mobivie.fr/se-deplacer/vivelo/,https://gbfs.partners.fifteen.eu/gbfs/vichy/gbfs.json,2.2,
 FR,V'lille,Lille,v_lille,https://www.ilevia.fr/v-lille,https://media.ilevia.fr/opendata/gbfs.json,2.3,
 FR,Voi Le Havre,Le Havre,voi_Le_Havre,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/336/gbfs.json,2.3,
 FR,Voi Marseille,Marseille,voi_Marseille,https://www.voi.com/,https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/66/gbfs.json,2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -596,7 +596,7 @@ FR,Vélocéo,Vannes,Veloceo_FR_Vannes,https://veloceo.kiceo.fr/,https://vannes-g
 FR,VéloCité,Besançon,besancon,https://www.velocite.besancon.fr/,https://api.cyclocity.fr/contracts/besancon/gbfs/gbfs.json,2.3,
 FR,VéloCité,Mulhouse,mulhouse,https://www.compte-mobilite.fr/services/velos-en-libre-service/,https://api.cyclocity.fr/contracts/mulhouse/gbfs/gbfs.json,2.3,
 FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?rub_code=1&thm_id=6,https://montpellier-fr.fifteen.site/gbfs/gbfs.json,1.0,
-FR,Vélopop,Avignon,velopop,https://velo-grandavignon.fr/fr/,https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/avignon/gbfs.json,1.0,key=NWNiMjc5YmQtMzVlOC00MmJiLTkyYTItNzZkMDViMzA2MzA2
+FR,Vélopop,Avignon,velopop,https://velo-grandavignon.fr/fr/,https://gbfs.partners.fifteen.eu/gbfs/avignon/gbfs.json,2.2,
 FR,VélOstan'lib,Nancy,nancy,https://www.velostanlib.fr/,https://api.cyclocity.fr/contracts/nancy/gbfs/gbfs.json,2.3,
 FR,VélÔToulouse,Toulouse,toulouse,http://www.velo.toulouse.fr/,https://api.cyclocity.fr/contracts/toulouse/gbfs/gbfs.json,2.3,
 FR,VéloZef,Brest,velozef,https://www.bibus.fr/services/velozef-le-velo-assistance-electrique-en-libre-service,https://gbfs.partners.fifteen.eu/gbfs/2.2/brest/en/gbfs.json,2.2,

--- a/systems.csv
+++ b/systems.csv
@@ -584,6 +584,7 @@ FR,Rhoule,Piriac-sur-Mer,rhoule,https://rhoule.ecovelo.mobi,https://api.gbfs.v3.
 FR,Rubis'Velo,Bourg-en-Bresse,beb,https://rubis.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/beb/gbfs.json,2.2 ; 3.0,
 FR,Semo Vélo,Louviers,semo,https://semo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/semo/gbfs.json,2.2 ; 3.0,
 FR,Tempovelo,Agen,tempovelo,https://tempovelo.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/tempovelo/gbfs.json,2.2 ; 3.0,
+FR,Ti Vélo,Landerneau,ti_velo,https://www.landerneau.bzh,https://gbfs.partners.fifteen.eu/gbfs/2.2/landerneau/en/gbfs.json,2.2,
 FR,TIER Paris,Paris,tier_paris,https://www.tier.app,https://data-sharing.tier-services.io/tier_paris/gbfs/3.0/,2.1 ; 2.2 ; 2.3 ; 3.0,
 FR,TLP Mobilites,Tarbes,tlpmobilites,https://tlpmobilites.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/tlpmobilites/gbfs.json,2.2 ; 3.0,
 FR,Velam,Amiens,amiens,https://velam.cyclocity.fr/,https://api.cyclocity.fr/contracts/amiens/gbfs/gbfs.json,2.3,

--- a/systems.csv
+++ b/systems.csv
@@ -594,7 +594,6 @@ FR,Vélhop - Strasbourg,"Strasbourg, FR",nextbike_ae,https://vls.velhop.strasbou
 FR,Vélo d'Aqui,Argelès-sur-Mer,velodaqui,https://velodaqui.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/velodaqui/gbfs.json,2.2 ; 3.0,
 FR,Vélo Tanlib,Niort,tanlib,https://tanlib.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/tanlib/gbfs.json,2.2 ; 3.0,
 FR,Vélo'Baie,Saint-Brieuc,saintbrieuc,https://www.saintbrieuc-armor-agglo.bzh/velobaie,https://gateway.prod.partners-fs37hd8.zoov.site/gbfs/2.2/saintbrieuc/en/gbfs.json,1.0,key=YmE1ZDVlNDYtMGIwNy00MGEyLWIxZWYtNGEwOGQ4NTYxNTYz
-FR,Vélocéo,Vannes,Veloceo_FR_Vannes,https://veloceo.kiceo.fr/,https://vannes-gbfs.klervi.net/gbfs/gbfs.json,,
 FR,VéloCité,Besançon,besancon,https://www.velocite.besancon.fr/,https://api.cyclocity.fr/contracts/besancon/gbfs/gbfs.json,2.3,
 FR,VéloCité,Mulhouse,mulhouse,https://www.compte-mobilite.fr/services/velos-en-libre-service/,https://api.cyclocity.fr/contracts/mulhouse/gbfs/gbfs.json,2.3,
 FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?rub_code=1&thm_id=6,https://montpellier-fr.fifteen.site/gbfs/gbfs.json,1.0,


### PR DESCRIPTION
## Whats Changed

This PR syncs [systems.csv](https://github.com/MobilityData/gbfs/blob/master/systems.csv) with the French NAP (https://transport.data.gouv.fr/api/datasets):
- Added 4 dock-based bikeshare feeds in Épinal, Auray, Vichy and Landerneau (powered by [Fifteen](https://fifteen.eu/en))
- Added 1 Voi shared scooters feed in Le Havre
- Added 1 carsharing feed in Belfort
- Fixed 3 dock-based bikeshare feeds in Lille, Montpellier and Belfort
- Upgraded 2 dock-based bikeshare feeds in Brest and Avignon (powered by [Fifteen](https://fifteen.eu/en))
- Removed 1 dock-based bikeshare feed in Vannes ([permanent shutdown](https://actu.fr/bretagne/vannes_56260/vannes-on-sait-enfin-ce-que-vont-devenir-les-velos-proposes-en-libre-service_61009579.html) in 2023)

cc @AntoineAugusti for visibility