### PR TITLE
Update feed URLs to facilitate data access in systems.csv

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -100,7 +100,7 @@ CA,Neuron Mobility,Vernon,neuron_yve,https://www.rideneuron.com,https://mds.neur
 CA,PBSC HQ,Montreal,pbsn,https://lyfturbansolutions.com/cities,https://pbsn.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,
 CA,Sobi Hamilton,Hamilton,sobi_hamilton,https://hamilton.socialbicycles.com/,https://hamilton.socialbicycles.com/opendata/gbfs.json,1.0,
 CA,UBC,UBC - Canada,13,https://gohopr.com/,https://gbfs.hopr.city/api/gbfs/13,2.2,
-CH,2EM Car Sharing,Switzerland,2em_cars,https://www.2em.ch,https://gbfs.prod.sharedmobility.ch/v2/gbfs/2em_cars/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
+CH,2EM Car Sharing,Switzerland,2em_cars,https://www.2em.ch,https://gbfs.prod.sharedmobility.ch/v2/gbfs/2em_cars/gbfs,2.3,https://github.com/SFOE/sharedmobility/blob/main/Access%20the%20data.md
 CH,Bird Basel,Basel,bird-basel,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/basel/gbfs.json,1.1 ; 2.3,
 CH,Bird Biel,Biel,bird-biel,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/biel/gbfs.json,1.1 ; 2.3,
 CH,Bird Bulle,Bulle,bird-bulle,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/bulle/gbfs.json,1.1 ; 2.3,
@@ -130,12 +130,12 @@ CH,edrive carsharing,Switzerland,edrivecarsharing_ch,https://www.edrivecarsharin
 CH,Lime Opfikon,Opfikon,lime_opfikon,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/opfikon/gbfs.json,2.2,
 CH,Lime Basel,Basel,lime_basel,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/v3/lime_basel/gbfs,2.3 ; 3.0,
 CH,Lime Uster,Uster,lime_uster,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/v3/lime_uster/gbfs,2.3 ; 3.0,
-CH,Lime Wetzikon,Wetzikon,lime_wetzikon,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_wetzikon/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
-CH,Lime Winterthur,Winterthur,lime_winterthur,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_winterthur/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
+CH,Lime Wetzikon,Wetzikon,lime_wetzikon,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_wetzikon/gbfs,2.3,https://github.com/SFOE/sharedmobility/blob/main/Access%20the%20data.md
+CH,Lime Winterthur,Winterthur,lime_winterthur,https://www.li.me/,https://gbfs.prod.sharedmobility.ch/v2/gbfs/lime_winterthur/gbfs,2.3,https://github.com/SFOE/sharedmobility/blob/main/Access%20the%20data.md
 CH,Lime Zug,Zug,lime_zug,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json,2.2,
 CH,Lime Zurich,Zurich,lime_zurich,https://www.li.me/,https://api.mobidata-bw.de/sharing/gbfs/v3/lime_zurich/gbfs,2.3 ; 3.0,
 CH,LINK Basel,Basel,Link_Basel,https://www.superpedestrian.com,https://mds.linkyour.city/gbfs/ch_basel/gbfs.json,2.2 ; 2.3,
-CH,Mobility,Switzerland,mobility,https://www.mobility.ch,https://gbfs.prod.sharedmobility.ch/v2/gbfs/mobility/gbfs,2.3,Authorization=gbfs@sharedmobility.ch
+CH,Mobility,Switzerland,mobility,https://www.mobility.ch,https://gbfs.prod.sharedmobility.ch/v2/gbfs/mobility/gbfs,2.3,https://github.com/SFOE/sharedmobility/blob/main/Access%20the%20data.md
 CH,nextbike Switzerland,Switzerland,nextbike_ch,https://www.nextbike.ch/de/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ch/gbfs.json,2.3,
 CH,PubliBike,Switzerland,publibike,https://www.publibike.ch,https://api.publibike.ch/v1/gbfs/v2/gbfs.json,2.3,
 CH,PickeBike Aubonne,Aubonne,pickebike_aubonne,https://www.pickebike.ch/de/,https://api.mobidata-bw.de/sharing/gbfs/v3/pickebike_aubonne/gbfs,2.3 ; 3.0,

--- a/systems.csv
+++ b/systems.csv
@@ -548,7 +548,7 @@ FR,Karu'Vélo,Pointe-à-Pitre,karu,https://karuvelo.ecovelo.mobi/,https://api.gb
 FR,Knot Strasbourg,Strasbourg,knot_strasbourg,https://knot.city/ride/where/strasbourg/,https://api.knotcity.io/gbfs/v3/strasbourg/gbfs.json,3.0,
 FR,La Baule,La Baule,labaule,https://labaule.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/labaule/gbfs.json,2.2 ; 3.0,
 FR,Le Marcel,Troyes,lemarcel,https://lemarcelavelo.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/lemarcel/gbfs.json,2.2 ; 3.0,
-FR,Le Vélo par TBM,Bordeaux,velo-tbm-bordeaux,https://www.infotbm.com/fr/le-velo,https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json,3.0,apiKey=opendata-bordeaux-metropole-flux-gtfs-rt
+FR,Le Vélo par TBM,Bordeaux,velo-tbm-bordeaux,https://www.infotbm.com/fr/le-velo,https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt,3.0,
 FR,LE vélo STAR,Rennes,le_velo_star,https://www.star.fr/le-velo/nos-offres/vls/,https://eu.ftp.opendatasoft.com/star/gbfs/gbfs.json,1.0,
 FR,Les Petites Reines,Les Sables-d'Olonne,petitesreines,https://lespetitesreines.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/petitesreines/gbfs.json,2.2 ; 3.0,
 FR,Levélo,Marseille,levelo_inurba_marseille,https://levelo.ampmetropole.fr,https://api.omega.fifteen.eu/gbfs/2.2/marseille/en/gbfs.json,1.0,key=MjE0ZDNmMGEtNGFkZS00M2FlLWFmMWItZGNhOTZhMWQyYzM2

--- a/systems.csv
+++ b/systems.csv
@@ -350,9 +350,9 @@ DE,SAP Walldorf,Walldorf,nextbike_ds,https://www.nextbike.de/walldorf/,https://g
 DE,Call a Bike,Germany,callabike,https://www.callabike.de/,https://api.mobidata-bw.de/sharing/gbfs/v3/callabike/gbfs,2.3 ; 3.0,
 DE,Call a Bike,Germany,callabike_ice,https://www.callabike.de/de/ice-stationen,https://api.mobidata-bw.de/sharing/gbfs/v3/callabike_ice/gbfs,2.3 ; 3.0,
 DE,LastenVelo Freiburg,Freiburg,lastenvelo_fr,https://www.lastenvelofreiburg.de/,https://api.mobidata-bw.de/sharing/gbfs/v3/lastenvelo_fr/gbfs,2.3 ; 3.0,
-DE,StadtRadHamburg,Hamburg,stadtrad_hamburg,https://stadtrad.hamburg.de/,https://apis.deutschebahn.com/db-api-marketplace/apis/shared-mobility-gbfs/2-2/de/StadtRadHamburg/gbfs,1.0,https://developers.deutschebahn.com/db-api-marketplace/apis/start
+DE,StadtRadHamburg,Hamburg,stadtrad_hamburg,https://stadtrad.hamburg.de/,https://apis.deutschebahn.com/db-api-marketplace/apis/shared-mobility-gbfs/v2/de/StadtRadHamburg/gbfs,1.0,https://developers.deutschebahn.com/db-api-marketplace/apis/start
 DE,RegioRadStuttgart,Stuttgart,regiorad_stuttgart,https://www.regioradstuttgart.de/,https://api.mobidata-bw.de/sharing/gbfs/v3/regiorad_stuttgart/gbfs,2.3 ; 3.0,
-DE,StadtRADLueneburg,Lübeburg,stadtrad_lueneburg,https://stadtradlueneburg.de/,https://apis.deutschebahn.com/db-api-marketplace/apis/shared-mobility-gbfs/2-2/de/StadtRADLueneburg/gbfs,1.0,https://developers.deutschebahn.com/db-api-marketplace/apis/start
+DE,StadtRADLueneburg,Lübeburg,stadtrad_lueneburg,https://stadtradlueneburg.de/,https://apis.deutschebahn.com/db-api-marketplace/apis/shared-mobility-gbfs/v2/de/StadtRADLueneburg/gbfs,1.0,https://developers.deutschebahn.com/db-api-marketplace/apis/start
 DE,sprintRAD,Hannover,nextbike_dh,https://www.nextbike.de/hannover/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_dh/gbfs.json,2.3,
 DE,StadtRad Greifswald,Greifswald,nextbike_ug,https://stadtrad-greifswald.de/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ug/gbfs.json,2.3,
 DE,Stadtmobil Stuttgart,Stuttgart,stadtmobil_stuttgart,https://stuttgart.stadtmobil.de/,https://api.mobidata-bw.de/sharing/gbfs/v3/stadtmobil_stuttgart/gbfs,2.3 ; 3.0,

--- a/systems.csv
+++ b/systems.csv
@@ -551,7 +551,7 @@ FR,Le Marcel,Troyes,lemarcel,https://lemarcelavelo.ecovelo.mobi,https://api.gbfs
 FR,Le Vélo par TBM,Bordeaux,velo-tbm-bordeaux,https://www.infotbm.com/fr/le-velo,https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt,3.0,
 FR,LE vélo STAR,Rennes,le_velo_star,https://www.star.fr/le-velo/nos-offres/vls/,https://eu.ftp.opendatasoft.com/star/gbfs/gbfs.json,1.0,
 FR,Les Petites Reines,Les Sables-d'Olonne,petitesreines,https://lespetitesreines.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/petitesreines/gbfs.json,2.2 ; 3.0,
-FR,Levélo,Marseille,levelo_inurba_marseille,https://levelo.ampmetropole.fr,https://api.omega.fifteen.eu/gbfs/2.2/marseille/en/gbfs.json,1.0,key=MjE0ZDNmMGEtNGFkZS00M2FlLWFmMWItZGNhOTZhMWQyYzM2
+FR,Levélo,Marseille,levelo_inurba_marseille,https://levelo.ampmetropole.fr,https://gbfs.omega.fifteen.eu/gbfs/2.2/marseille/en/gbfs.json,2.2,
 FR,Libélo,Valence,libelo,https://www.vrd-mobilites.fr/velo/,https://valence.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,
 FR,Lime Marseille,Marseille,lime_marseille,https://www.li.me,https://data.lime.bike/api/partners/v2/gbfs/marseille/gbfs.json,2.2,
 FR,Lime Paris,Paris,lime_paris,https://li.me/,https://data.lime.bike/api/partners/v2/gbfs/paris/gbfs.json,2.2,
@@ -593,7 +593,7 @@ FR,Vélib' Metropole,Paris,Paris,https://www.velib-metropole.fr/,https://velib-m
 FR,Vélhop - Strasbourg,"Strasbourg, FR",nextbike_ae,https://vls.velhop.strasbourg.eu/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ae/gbfs.json,2.3,
 FR,Vélo d'Aqui,Argelès-sur-Mer,velodaqui,https://velodaqui.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/velodaqui/gbfs.json,2.2 ; 3.0,
 FR,Vélo Tanlib,Niort,tanlib,https://tanlib.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/tanlib/gbfs.json,2.2 ; 3.0,
-FR,Vélo'Baie,Saint-Brieuc,saintbrieuc,https://www.saintbrieuc-armor-agglo.bzh/velobaie,https://gateway.prod.partners-fs37hd8.zoov.site/gbfs/2.2/saintbrieuc/en/gbfs.json,1.0,key=YmE1ZDVlNDYtMGIwNy00MGEyLWIxZWYtNGEwOGQ4NTYxNTYz
+FR,Vélo'Baie,Saint-Brieuc,saintbrieuc,https://www.saintbrieuc-armor-agglo.bzh/velobaie,https://gbfs.partners.fifteen.eu/gbfs/2.2/saintbrieuc/en/gbfs.json,2.2,
 FR,VéloCité,Besançon,besancon,https://www.velocite.besancon.fr/,https://api.cyclocity.fr/contracts/besancon/gbfs/gbfs.json,2.3,
 FR,VéloCité,Mulhouse,mulhouse,https://www.compte-mobilite.fr/services/velos-en-libre-service/,https://api.cyclocity.fr/contracts/mulhouse/gbfs/gbfs.json,2.3,
 FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?rub_code=1&thm_id=6,https://montpellier-fr.fifteen.site/gbfs/gbfs.json,1.0,


### PR DESCRIPTION
## Whats Changed

This PR updates 5 feed URLs to facilitate data access:
- Replaced 2 feed URLs with URLs that don't require a key for LeVélo Marseille, FR and Vélo'Baie Saint-Brieuc, FR
- Appended the key to 1 feed URL as the key is hard coded in [gbfs.json](https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt) for Le Vélo Bordeaux, FR
- Fixed 2 Deutsche Bahn URLs (the producer replaced `2-2` in the feed URL with `v2` on July 28, 2024)

This PR updates the auth info of 4 sharedmobility.ch feeds.