### PR TITLE
feat: notify mobility-feed-api on systems update

### DIFF
--- a/.github/workflows/systems_update.yml
+++ b/.github/workflows/systems_update.yml
@@ -1,0 +1,29 @@
+name: Notify Mobility Feed API on Systems Update
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - systems.csv  # Only run if this file changes
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets from 1Password
+        id: onepw_secrets
+        uses: 1password/load-secrets-action@v2.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
+
+      - name: Send a notification to the mobility-feed-api
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ env.CREDENTIALS }}
+          repository: MobilityData/mobility-feed-api
+          event-type: gbfs-systems-updated


### PR DESCRIPTION
**Summary:**
Closes [#675](https://github.com/MobilityData/mobility-feed-api/issues/675).
This PR adds a GitHub Action that sends a notification to the [`mobility-feed-api`](https://github.com/MobilityData/mobility-feed-api) repository whenever `systems.csv` is updated. This ensures the [Mobility Database](https://mobilitydatabase.org/) stays in sync with the latest changes to `systems.csv`.

