### PR TITLE
Remove feed system_id targumures

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -1006,7 +1006,6 @@ RO,nextbike Romania,Focșani,nextbike_nw,https://nextbike.ro/,https://gbfs.nextb
 RO,Saturn,Saturn,nextbike_rs,https://www.nextbike.ro/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_rs/gbfs.json,2.3,,,
 RO,Sibiu BikeCity,Sibiu,sibiu_bikecity,https://bikecity.sibiu.ro,https://sibiu.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,
 RO,Slatina Velo City,"Slatina, RO",nextbike_rv,https://www.slatinavelocity.ro/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_rv/gbfs.json,2.3,,,
-RO,Târgu-Mures,Târgu-Mures,targumures,,https://targumures.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,
 RO,Topoloveni Bike,Topoloveni,nextbike_rt,https://www.nextbike.ro/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_rt/gbfs.json,2.3,,,
 RO,Velo Sântana,Sântana,santana_bikecity,https://velosantana.ro,https://santana.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,
 SA,Dott Jeddah,Jeddah,dott-jeddah,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/jeddah/gbfs.json,2.3,,,


### PR DESCRIPTION
## Context
Târgu-Mures, RO, has no commercial site URL in systems.csv. 

After a short investigation, it seems that this system permanently shutdown. Indeed:

- The feed URL is from PBSC ([publicbikesystem.net](http://publicbikesystem.net/)) and PBSC website does not list Târgu-Mures, Romania on their [cities](https://lyfturbansolutions.com/cities) page.
- The 5 stations of the system are empty (see [visualization](https://gbfs-validator.mobilitydata.org/visualization?url=https%3A%2F%2Ftargumures.publicbikesystem.net%2Fcustomer%2Fgbfs%2Fv2%2Fgbfs.json)).

## What's Changed
This PR removes the feed with `system_id` 'targumures' due to what seems to be a permanent shutdown.

Thanks @mjmsmith for raising this issue 🙏 