### PR TITLE
Add 1 feed from QuickRent truck sharing in Switzerland

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -141,6 +141,7 @@ CH,PubliBike,Switzerland,publibike,https://www.publibike.ch,https://api.publibik
 CH,PickeBike Aubonne,Aubonne,pickebike_aubonne,https://www.pickebike.ch/de/,https://api.mobidata-bw.de/sharing/gbfs/v3/pickebike_aubonne/gbfs,2.3 ; 3.0,,,
 CH,PickeBike Basel,Basel,pickebike_basel,https://www.pickebike.ch/de/,https://api.mobidata-bw.de/sharing/gbfs/v3/pickebike_basel/gbfs,2.3 ; 3.0,,,
 CH,PickeBike Fribourg,Fribourg,pickebike_fribourg,https://www.pickebike.ch/de/,https://api.mobidata-bw.de/sharing/gbfs/v3/pickebike_fribourg/gbfs,2.3 ; 3.0,,,
+CH,QuickRent,Switzerland,quickrent.ch,https://www.quickrent.ch/,https://quickrent.ch/sbb/api/v1/gbfs,3.0,,,
 CH,Share Birrer,Switzerland,share_birrer_ch,https://www.share-birrer.ch/,https://www.share-birrer.ch/gbfs/gbfs.json,2.2,,,
 CH,sharedmobility.ch,Switzerland,sharedmobility.ch,https://www.sharedmobility.ch/info,https://www.sharedmobility.ch/gbfs.json,2.0,,,
 CH,Velospot,Switzerland,velospot_ch,https://www.velospot.info/customer/public,https://api.mobidata-bw.de/sharing/gbfs/v3/velospot_ch/gbfs,2.3 ; 3.0,,,


### PR DESCRIPTION
## Context
[QuickRent.ch](http://quickrent.ch/) implemented a GBFS feed.

## What's Changed
Adds the GBFS feed for QuickRent truck sharing in Switzerland 🚚 