### PR TITLE
Add 1 feed from Beryl in Worcester, GB

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -662,6 +662,7 @@ GB,Beryl - Watford,Watford,beryl_watford,https://beryl.cc/scheme/watford,https:/
 GB,Beryl - West Midlands,West Midlands,beryl_west_midlands,https://beryl.cc/scheme/west-midlands,https://gbfs.beryl.cc/v2_2/West_Midlands/gbfs.json,2.1 ; 2.2,,,
 GB,Beryl - Westminster Cargo Bike,Westminster,beryl_westminster_cargo_bike,https://beryl.cc/,https://gbfs.beryl.cc/v2_2/Westminster_Cargo_Bike/gbfs.json,2.1 ; 2.2,,,
 GB,Beryl - Wool,Wool,beryl_wool,https://beryl.cc/scheme/wool,https://gbfs.beryl.cc/v2_2/Wool/gbfs.json,2.1 ; 2.2,,,
+GB,Beryl - Worcester,Worcester,beryl_worcester,https://beryl.cc/scheme/worcester,https://gbfs.beryl.cc/v2_2/Worcester/gbfs.json,2.1 ; 2.2,,,
 GB,Co-bikes,Exeter,nextbike_eu,https://www.co-bikes.co.uk/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_eu/gbfs.json,2.3,,,
 GB,Demoland,Great Britain,nextbike_tb,https://www.nextbike.de/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_tb/gbfs.json,2.3,,,
 GB,Donkey Republic Charlbury,Charlbury,donkey_charlbury,https://www.donkey.bike/cities/bike-rental-charlbury/,https://stables.donkey.bike/api/public/gbfs/2/donkey_charlbury/gbfs.json,1.0 ; 2.3,,,


### PR DESCRIPTION
## Context
citybik.es API (https://api.citybik.es/v2/networks) contains one `gbfs_href` which is missing from systems.csv.

## What's Changed
This PR adds the GBFS feed for Beryl - Worcester 🇬🇧 

Thanks @eskerda 🙏 