### PR TITLE
Add 2 feeds from Fifteen and Transdev

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -627,6 +627,7 @@ FR,Vélo'Baie,Saint-Brieuc,saintbrieuc,https://www.saintbrieuc-armor-agglo.bzh/v
 FR,VéloCité,Besançon,besancon,https://www.velocite.besancon.fr/,https://api.cyclocity.fr/contracts/besancon/gbfs/gbfs.json,2.3,,,
 FR,VéloCité Mulhouse,Mulhouse,nextbike_af,https://velocite-mulhouse.fr/fr/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_af/gbfs.json,2.3,,,
 FR,Vélomagg',Montpellier,montpellier,https://www.tam-voyages.com/presentation/?rub_code=1&thm_id=6,https://montpellier-fr.fifteen.site/gbfs/gbfs.json,1.0,,,
+FR,Vélonecy,Annecy,velonecy60minutes_annecy,https://mobilites.grandannecy.fr/,https://gbfs.partners.fifteen.eu/gbfs/2.2/annecy/en/gbfs.json,2.2,,,
 FR,Vélopop,Avignon,velopop,https://velo-grandavignon.fr/fr/,https://gbfs.partners.fifteen.eu/gbfs/avignon/gbfs.json,2.2,,,
 FR,VélOstan'lib,Nancy,nancy,https://www.velostanlib.fr/,https://api.cyclocity.fr/contracts/nancy/gbfs/gbfs.json,2.3,,,
 FR,VélÔToulouse,Toulouse,toulouse,http://www.velo.toulouse.fr/,https://api.cyclocity.fr/contracts/toulouse/gbfs/gbfs.json,2.3,,,

--- a/systems.csv
+++ b/systems.csv
@@ -617,6 +617,7 @@ FR,Ti Vélo,Landerneau,ti_velo,https://www.landerneau.bzh,https://gbfs.partners.
 FR,TIER Paris,Paris,tier_paris,https://www.tier.app,https://data-sharing.tier-services.io/tier_paris/gbfs/3.0/,2.1 ; 2.2 ; 2.3 ; 3.0,,,
 FR,TLP Mobilites,Tarbes,tlpmobilites,https://tlpmobilites.ecovelo.mobi/,https://api.gbfs.v3.0.ecovelo.mobi/tlpmobilites/gbfs.json,2.2 ; 3.0,,,
 FR,Twisto Vélolib,Caen,twisto_velolib_caen,https://www.twisto.fr/se-deplacer/velo/velolib,https://gbfs.partners.fifteen.eu/gbfs/2.2/caen/en/gbfs.json,2.2,,,
+FR,Vel’in,Calais,calais-velos,https://www.vel-in.fr/,https://stce.transdev-hdf.fr/gbfs/,1.0,,,
 FR,Velam,Amiens,amiens,https://velam.cyclocity.fr/,https://api.cyclocity.fr/contracts/amiens/gbfs/gbfs.json,2.3,,,
 FR,Velect'in,Calais,calais,https://velectin.ecovelo.mobi,https://api.gbfs.v3.0.ecovelo.mobi/calais/gbfs.json,2.2 ; 3.0,,,
 FR,Vélib' Metropole,Paris,Paris,https://www.velib-metropole.fr/,https://velib-metropole-opendata.smovengo.cloud/opendata/Velib_Metropole/gbfs.json,1.0,,,


### PR DESCRIPTION
## Context
🇫🇷 The French National Access Point API (https://transport.data.gouv.fr/api/datasets) contains 2 GBFS feeds which are missing from systems.csv.

## What's Changed
This PR adds the GBFS feeds for:
- Vélonecy in Annecy, FR by Fifteen
- Vel’in in Calais, FR by Transdev

Thanks to the French NAP team @AntoineAugusti @Brewennn @stephane-pignal 🙏 