### PR TITLE
chore: remove offline region

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -258,7 +258,6 @@ DE,Dott Detmold,Detmold,dott-detmold,https://ridedott.com/,https://gbfs.api.ride
 DE,Dott Dortmund,Dortmund,dott-dortmund,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/dortmund/gbfs.json,2.3,,,
 DE,Dott Duisburg,Duisburg,dott-duisburg,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/duisburg/gbfs.json,2.3,,,
 DE,Dott Dusseldorf,Dusseldorf,dott-dusseldorf,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/dusseldorf/gbfs.json,2.3,,,
-DE,Dott Elmshorn,Elmshorn,dott-elmshorn,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/elmshorn/gbfs.json,2.3,,,
 DE,Dott Erfurt,Erfurt,dott-erfurt,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/erfurt/gbfs.json,2.3,,,
 DE,Dott Erlangen,Erlangen,dott-erlangen,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/erlangen/gbfs.json,2.3,,,
 DE,Dott Essen,Essen,dott-essen,https://ridedott.com/,https://gbfs.api.ridedott.com/public/v2/essen/gbfs.json,2.3,,,


### PR DESCRIPTION
The removed dott region is responding with ERR_REGION_NOT_FOUND. There are also no rides listed within their own app.